### PR TITLE
add array type to Trestle::Attribute

### DIFF
--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -53,9 +53,9 @@ module Trestle
       def default_attributes
         admin.model.columns.map do |column|
           if column.name.end_with?("_id") && (reflection = admin.model.reflections[column.name.sub(/_id$/, '')])
-            Attribute::Association.new(admin, column.name, reflection.klass)
+            Attribute::Association.new(admin, column.name, reflection.klass, false)
           else
-            Attribute.new(admin, column.name, column.type)
+            Attribute.new(admin, column.name, column.type, column.array)
           end
         end
       end

--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -55,7 +55,7 @@ module Trestle
           if column.name.end_with?("_id") && (reflection = admin.model.reflections[column.name.sub(/_id$/, '')])
             Attribute::Association.new(admin, column.name, reflection.klass, false)
           else
-            Attribute.new(admin, column.name, column.type, column.array)
+            Attribute.new(admin, column.name, column.type, false)
           end
         end
       end

--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -55,7 +55,7 @@ module Trestle
           if column.name.end_with?("_id") && (reflection = admin.model.reflections[column.name.sub(/_id$/, '')])
             Attribute::Association.new(admin, column.name, reflection.klass, false)
           else
-            Attribute.new(admin, column.name, column.type, false)
+            Attribute.new(admin, column.name, column.type, column.array)
           end
         end
       end

--- a/lib/trestle/attribute.rb
+++ b/lib/trestle/attribute.rb
@@ -1,9 +1,9 @@
 module Trestle
   class Attribute
-    attr_reader :admin, :name, :type
+    attr_reader :admin, :name, :type, :array
 
-    def initialize(admin, name, type)
-      @admin, @name, @type = admin, name.to_sym, type
+    def initialize(admin, name, type, array)
+      @admin, @name, @type, @array = admin, name.to_sym, type, array
     end
 
     def association?
@@ -15,7 +15,11 @@ module Trestle
     end
 
     def text?
-      type == :text
+      type == :text && !array
+    end
+
+    def array?
+      type == :text && array
     end
 
     def datetime?
@@ -37,8 +41,8 @@ module Trestle
     class Association < Attribute
       attr_reader :association_class
 
-      def initialize(admin, name, association_class)
-        super(admin, name, :association)
+      def initialize(admin, name, association_class, array)
+        super(admin, name, :association, array)
         @association_class = association_class
       end
 

--- a/spec/trestle/attribute_spec.rb
+++ b/spec/trestle/attribute_spec.rb
@@ -26,7 +26,7 @@ describe Trestle::Attribute do
 
   describe "#array?" do
     it "returns true if the attribute has type text and is array" do
-      expect(Trestle::Attribute.new(admin, :body, :text, false)).to be_an_instance_of(Array)
+      expect(Trestle::Attribute.new(admin, :body, :text, true).array?).to be_truthy 
     end
   end
 

--- a/spec/trestle/attribute_spec.rb
+++ b/spec/trestle/attribute_spec.rb
@@ -4,7 +4,7 @@ describe Trestle::Attribute do
   let(:model) { double(primary_key: "id", inheritance_column: "type") }
   let(:admin) { double(model: model) }
 
-  subject(:attribute) { Trestle::Attribute.new(admin, :name, :string) }
+  subject(:attribute) { Trestle::Attribute.new(admin, :name, :string, false) }
 
   describe "#association?" do
     it "returns false" do
@@ -14,52 +14,58 @@ describe Trestle::Attribute do
 
   describe "#boolean?" do
     it "returns true if the attribute has type boolean" do
-      expect(Trestle::Attribute.new(admin, :published, :boolean)).to be_boolean
+      expect(Trestle::Attribute.new(admin, :published, :boolean, false)).to be_boolean
     end
   end
 
   describe "#text?" do
     it "returns true if the attribute has type text" do
-      expect(Trestle::Attribute.new(admin, :body, :text)).to be_text
+      expect(Trestle::Attribute.new(admin, :body, :text, false)).to be_text
+    end
+  end
+
+  describe "#array?" do
+    it "returns true if the attribute has type text and is array" do
+      expect(Trestle::Attribute.new(admin, :body, :text, false)).to be_an_instance_of(Array)
     end
   end
 
   describe "#datetime?" do
     it "returns true if the attribute has type date" do
-      expect(Trestle::Attribute.new(admin, :timestamp, :date)).to be_datetime
+      expect(Trestle::Attribute.new(admin, :timestamp, :date, false)).to be_datetime
     end
 
     it "returns true if the attribute has type time" do
-      expect(Trestle::Attribute.new(admin, :timestamp, :time)).to be_datetime
+      expect(Trestle::Attribute.new(admin, :timestamp, :time, false)).to be_datetime
     end
 
     it "returns true if the attribute has type datetime" do
-      expect(Trestle::Attribute.new(admin, :timestamp, :datetime)).to be_datetime
+      expect(Trestle::Attribute.new(admin, :timestamp, :datetime, false)).to be_datetime
     end
   end
 
   describe "#primary_key?" do
     it "returns true if the attribute name matches the admin model's primary key" do
-      expect(Trestle::Attribute.new(admin, :id, :integer)).to be_primary_key
+      expect(Trestle::Attribute.new(admin, :id, :integer, false)).to be_primary_key
     end
   end
 
   describe "#inheritance_column?" do
     it "returns true if the attribute name matches the admin model's STI column" do
-      expect(Trestle::Attribute.new(admin, :type, :string)).to be_inheritance_column
+      expect(Trestle::Attribute.new(admin, :type, :string, false)).to be_inheritance_column
     end
   end
 
   describe "#counter_cache?" do
     it "returns true if the attribute name is a counter cache column" do
-      expect(Trestle::Attribute.new(admin, :posts_count, :integer)).to be_counter_cache
+      expect(Trestle::Attribute.new(admin, :posts_count, :integer, false)).to be_counter_cache
     end
   end
 
   describe Trestle::Attribute::Association do
     let(:association_class) { double(name: "User") }
 
-    subject(:association) { Trestle::Attribute::Association.new(admin, :user_id, association_class) }
+    subject(:association) { Trestle::Attribute::Association.new(admin, :user_id, association_class, false) }
 
     describe "#association?" do
       it "returns true" do


### PR DESCRIPTION
Hi ! 

It seems like resources having Postgresql's array type aren't supported, it crashes at line:
`content = text.truncate(length, options)`

Which throws:
`undefined method 'truncate' for []:Array`

This PR fixes it, by adding an `array` attribute to the class Trestle::Attribute

Let me know if I can make anything better. 