### PR TITLE
Safely access trestle:navigation:collapsed cookie

### DIFF
--- a/app/views/trestle/shared/_sidebar.html.erb
+++ b/app/views/trestle/shared/_sidebar.html.erb
@@ -12,7 +12,7 @@
 
   <div class="app-sidebar-inner">
     <nav class="app-nav">
-      <% collapsed = cookies["trestle:navigation:collapsed"].split(",") %>
+      <% collapsed = cookies["trestle:navigation:collapsed"].try(:split, ",") || [] %>
       <% Trestle.navigation.each do |group, items| %>
         <ul<% if collapsed.include?(group.label.parameterize) %> class="collapsed"<% end %>>
           <% if group.present? %>


### PR DESCRIPTION
This commit adds a fallback for the case when the `trestle:navigation:collapsed` cookie doesn't exist.