### PR TITLE
Add support for menu items to use model translation

### DIFF
--- a/lib/trestle/navigation/item.rb
+++ b/lib/trestle/navigation/item.rb
@@ -40,7 +40,8 @@ module Trestle
       end
 
       def label
-        I18n.t("admin.navigation.items.#{name}", default: name.to_s.titlecase)
+        I18n.t("admin.navigation.items.#{name}", default: false) ||
+        I18n.t("activerecord.models.#{name.to_s.singularize}.other", default: name.to_s.titlecase)
       end
 
       def icon

--- a/spec/trestle/navigation/item_spec.rb
+++ b/spec/trestle/navigation/item_spec.rb
@@ -4,7 +4,7 @@ describe Trestle::Navigation::Item do
   subject(:item) { Trestle::Navigation::Item.new(:test) }
 
   it "has a label based on the internationalized name" do
-    expect(I18n).to receive(:t).with("admin.navigation.items.test", default: "Test").and_return("Test")
+    expect(I18n).to receive(:t).with("admin.navigation.items.test", default: false).and_return("Test")
     expect(item.label).to eq("Test")
   end
 


### PR DESCRIPTION
I am developing an application that uses the portuguese language by default, so I need to have the menu items also in Portuguese. To have all the menu items in Portuguese, I would need to put all the links this way: 

```yml
pt-BR:
  admin:
    navigation:
      items:
        users: Usuários
        urls: URLs
        profile: Perfis
        gender: Generos
```

But my models are already all translated into portuguese. So if I put all those translations into the menu items again it's kind of redundant situation, right? To fix this I made a change that allows the menu items to be automatically translated, just if there is a translation for it, of course, and I also left the option of a more dynamic translation if necessary.

Example:
```yml
pt-BR:
  admin:
    navigation:
      items:
        users: Os Usuários
        gender: Os Generos

  activerecord:
    models:
      user:
        one: Usuário
        other: Usuários
      url:
        one: Url
        other: Urls
      profile:
        one: Perfil
        other: Perfis
      gender:
        one: Gênero
        other: Generos
```

This will build a menu like that, now:

![image](https://user-images.githubusercontent.com/7697524/30526397-2b5a31ba-9bf0-11e7-862c-735dcf6f695e.png)

It's a small change that makes it even easier to use Trestle with I18n support.