### PR TITLE
Add :controller option for admin builder

### DIFF
--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -49,7 +49,11 @@ module Trestle
       end
 
       def controller_namespace
-        "#{name.underscore}/admin"
+        if options[:controller]
+          options[:controller].name.underscore.sub(/_controller$/, '')
+        else
+          "#{name.underscore}/admin"
+        end
       end
 
       def path(action=:index, options={})

--- a/lib/trestle/admin/builder.rb
+++ b/lib/trestle/admin/builder.rb
@@ -21,12 +21,17 @@ module Trestle
         scope.const_set("#{name.to_s.camelize}Admin", @admin)
 
         # Define admin controller class
-        # This is done using class_eval rather than Class.new so that the full
-        # class name and parent chain is set when Rails' inherited hooks are called.
-        @admin.class_eval("class AdminController < #{self.class.controller.name}; end")
+        if options[:controller]
+          @controller = options[:controller]
+        else
+          # This is done using class_eval rather than Class.new so that the full
+          # class name and parent chain is set when Rails' inherited hooks are called.
+          @admin.class_eval("class AdminController < #{self.class.controller.name}; end")
 
-        # Set a reference on the controller class to the admin class
-        @controller = @admin.const_get("AdminController")
+          # Set a reference on the controller class to the admin class
+          @controller = @admin.const_get("AdminController")
+        end
+
         @controller.instance_variable_set("@admin", @admin)
       end
 

--- a/spec/trestle/admin/builder_spec.rb
+++ b/spec/trestle/admin/builder_spec.rb
@@ -31,6 +31,14 @@ describe Trestle::Admin::Builder do
     expect(::TestAdmin::AdminController.admin).to eq(::TestAdmin)
   end
 
+  it "accepts custom controller class" do
+    controller = Class.new(Trestle::Admin::Controller)
+
+    Trestle::Admin::Builder.build(:test, controller: controller)
+    expect(::TestAdmin).not_to be_const_defined(:AdminController)
+    expect(controller.admin).to eq(::TestAdmin)
+  end
+
   it "transfer the options on the Admin class" do
     options = { custom: "option" }
     Trestle::Admin::Builder.build(:test, options)


### PR DESCRIPTION
Allow a custom controller to be defined as admin controller.
This allow a more cleaner way to redefine controller actions and
action filters.