### PR TITLE
Rails 5.1 Updates

### DIFF
--- a/lib/trestle/version.rb
+++ b/lib/trestle/version.rb
@@ -1,3 +1,3 @@
 module Trestle
-  VERSION = "0.8.5"
+  VERSION = "0.8.6"
 end

--- a/trestle.gemspec
+++ b/trestle.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "railties",           ">= 4.2.0"
   spec.add_dependency "activemodel",        ">= 4.2.0"
-  spec.add_dependency "sass-rails",         "~> 5.0.6"
-  spec.add_dependency "autoprefixer-rails", "~> 7.1.2"
-  spec.add_dependency "kaminari",           "~> 1.0.1"
+  spec.add_dependency "sass-rails",         ">= 5.0.6"
+  spec.add_dependency "autoprefixer-rails", ">= 7.1.2"
+  spec.add_dependency "kaminari",           ">= 1.0.1"
 
   spec.add_development_dependency "bundler",     "~> 1.12"
   spec.add_development_dependency "rake",        "~> 10.0"


### PR DESCRIPTION
Currently, some of the restrictions on the dependencies inside Trestle won't allow it to be used within a Rails 5.1 application. I've opened that up a bit liberally, but it's allowed me to use it within a Rails 5.1 app I'm working on.