### PR TITLE
Add support for flatpickr i18n date/time format, CS locale

### DIFF
--- a/app/assets/javascripts/trestle/components/_datepicker.js
+++ b/app/assets/javascripts/trestle/components/_datepicker.js
@@ -2,14 +2,14 @@ Trestle.init(function(e, root) {
   $(root).find('input[type="date"][data-picker="true"]').flatpickr({
     allowInput: true,
     altInput:   true,
-    altFormat:  "m/d/Y",
+    altFormat:  Trestle.i18n["flatpickr.formats.date"],
   });
 
   $(root).find('input[type="datetime"][data-picker="true"], input[type="datetime-local"][data-picker="true"]').flatpickr({
     enableTime: true,
     allowInput: true,
     altInput:   true,
-    altFormat:  "m/d/Y h:i K",
+    altFormat:  Trestle.i18n["flatpickr.formats.datetime"],
   });
 
   $(root).find('input[type="time"][data-picker="true"]').flatpickr({
@@ -17,6 +17,6 @@ Trestle.init(function(e, root) {
     noCalendar: true,
     allowInput: true,
     altInput:   true,
-    altFormat:  "h:i K"
+    altFormat:  Trestle.i18n["flatpickr.formats.time"]
   });
 });

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,0 +1,80 @@
+cs:
+  trestle:
+    title: "Administrace Trestle"
+    footer: "Poháněno systémem Trestle"
+    version: "Verze"
+
+    flash:
+      success:
+        title: "Akce úspěšně dokončena!"
+        create: "Položka byla vytvořena."
+        update: "Položka byla aktualizováná."
+        destroy: "Položka byla smazána."
+
+      failure:
+        title: "Nastala chyba!"
+        create: "Prosím opravte chyby zvýrazněné níže."
+        update: "Prosím opravte chyby zvýrazněné níže."
+        destroy: "Položku nebylo možné smazat."
+
+    helpers:
+      page_entries_info:
+        one_page:
+          display_entries:
+            zero: "Nezobrazeny žádné položky"
+            one: "Zobrazena <strong>1</strong> položka"
+            other: "Zobrazeno <strong>%{count}</strong> položek"
+            few: "Zobrazeny <strong>%{count}</strong> položky"
+
+        more_pages:
+          display_entries: "Zobrazeny položky <strong>%{first}</strong> až <strong>%{last}</strong> z celkem <b>%{total}</b>"
+
+    onboarding:
+      welcome: "Vítejte v administraci Trestle"
+      no_admins: "Začněte přidáním souboru do <code>app/admin</code>."
+      no_template: "Pro přizpůsobení šablony vytvořte  <code>%{path}</code>."
+      no_form: "Pro přidání formuláře nadefinujte form blok, nebo vytvořte soubor <code>_form.html</code>."
+
+    dialog:
+      error: "Požadavek nemohl být dokončen."
+
+  flatpickr:
+    formats:
+      date: "d/m/Y"
+      datetime: "d/m/Y H:i"
+      time: "H:i"
+
+  admin:
+    titles:
+      index: Přehled
+      edit: Upravit položku
+      new: Nová položka
+
+    buttons:
+      new: "Přidat"
+      save: Uložit
+      delete: Smazat
+      ok: "OK"
+
+    breadcrumbs:
+      home: "Úvod"
+
+    table:
+      headers:
+        id: "ID"
+
+    form:
+      select:
+        prompt: "- Prosím vyberte -"
+
+    confirmation:
+      title: "Jste si jisti?"
+      delete: "Ano"
+      cancel: "Nemazat"
+
+    ui:
+      toggle_navigation: "Přepnout navigaci"
+      toggle_sidebar: "Přepnout boční panel"
+
+    format:
+      blank: "Žádný"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,12 @@ en:
     dialog:
       error: "The request could not be completed."
 
+  flatpickr:
+    formats:
+      date: "m/d/Y"
+      datetime: "m/d/Y h:i K"
+      time: "h:i K"
+
   admin:
     titles:
       index: "Listing %{pluralized_model_name}"

--- a/lib/trestle/configuration.rb
+++ b/lib/trestle/configuration.rb
@@ -83,7 +83,7 @@ module Trestle
     end
 
     # List of i18n keys to pass into the Trestle.i18n JavaScript object
-    option :javascript_i18n_keys, ["admin.confirmation.title", "admin.confirmation.delete", "admin.confirmation.cancel", "trestle.dialog.error", "admin.buttons.ok"]
+    option :javascript_i18n_keys, ["admin.confirmation.title", "admin.confirmation.delete", "admin.confirmation.cancel", "trestle.dialog.error", "admin.buttons.ok", "flatpickr.formats.date", "flatpickr.formats.datetime", "flatpickr.formats.time"]
 
     # List of load paths for where to find admin definitions
     option :load_paths, [

--- a/lib/trestle/form/fields/date_picker.rb
+++ b/lib/trestle/form/fields/date_picker.rb
@@ -1,7 +1,7 @@
 module Trestle::Form::Fields::DatePicker
   def extract_options!
     options[:prepend] ||= options.key?(:icon) ? options.delete(:icon) : default_icon
-    options.deep_merge!(data: { picker: options.fetch(:picker, true })
+    options.deep_merge!(data: { picker: options.fetch(:picker, true) })
 
     super
   end

--- a/lib/trestle/form/fields/date_picker.rb
+++ b/lib/trestle/form/fields/date_picker.rb
@@ -1,7 +1,7 @@
 module Trestle::Form::Fields::DatePicker
   def extract_options!
     options[:prepend] ||= options.key?(:icon) ? options.delete(:icon) : default_icon
-    options.merge!(data: { picker: options.key?(:picker) ? options.delete(:picker) : true })
+    options.deep_merge!(data: { picker: options.fetch(:picker, true })
 
     super
   end


### PR DESCRIPTION
Change summary:

- Add locale file for Czech language
- Allow Flatpickr datetime, date and time format to be customized via locaes
- Fixes `Trestle::Form::Fields::DatePicker` to allow user to customize Flatpickr using `data-X` attributes

Flatpickr customization example:
```ruby
date_field :issued_at, data: { :"allow-input" => false }
```