### PR TITLE
Fix cs locales

### DIFF
--- a/config/locales/cs.rb
+++ b/config/locales/cs.rb
@@ -1,0 +1,18 @@
+{
+  cs: {
+    date: {
+      formats: {
+        trestle_date: proc { |date| "%d/%m/%Y" },
+        trestle_calendar: "%d/%m/%Y"
+      }
+    },
+
+    time: {
+      formats: {
+        trestle_date: proc { |time| "%d/%m/%Y" },
+        trestle_time: "%H:%M",
+        trestle_time_with_seconds: "%H:%M:%S"
+      }
+    }
+  }
+}

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -71,7 +71,7 @@ cs:
       toggle_sidebar: "Přepnout boční panel"
 
     format:
-      blank: "Žádný"
+      blank: "-"
 
     datepicker:
       formats:


### PR DESCRIPTION
Change summary:

- Add cs.rb locale file for time and date formats
- Change translation for `admin.format.blank` to a dash because of incorrect conjugation if few cases