### PR TITLE
Don't generate row link when show action is removed

### DIFF
--- a/lib/trestle/table/row.rb
+++ b/lib/trestle/table/row.rb
@@ -32,7 +32,7 @@ module Trestle
         def options(instance)
           options = Trestle::Options.new
 
-          if table.admin && table.autolink?
+          if table.admin && table.autolink? && table.admin.actions.include?(:show)
             options.merge!(data: { url: admin_url_for(instance) })
             options.merge!(data: { behavior: "dialog" }) if table.admin.form.dialog?
           end


### PR DESCRIPTION
Change summary:

- Prevent `ActionController::UrlGenerationError` when `show` action is removed using `remove_action :show`
- Mentioned in https://github.com/TrestleAdmin/trestle/issues/32