### PR TITLE
Singular resources

### DIFF
--- a/app/views/trestle/resource/edit.html.erb
+++ b/app/views/trestle/resource/edit.html.erb
@@ -1,7 +1,7 @@
 <% title = t("admin.titles.edit", default: "Editing %{model_name}", model_name: admin.model_name.titleize, pluralized_model_name: admin.model_name.plural.titleize) %>
 
 <% content_for(:title, title) %>
-<% breadcrumb title %>
+<% breadcrumb(title) %>
 
 <% content_for(:primary_toolbar) do %>
   <%= button_tag t("admin.buttons.save", default: "Save %{model_name}", model_name: admin.model_name), class: "btn btn-success btn-lg" if admin.actions.include?(:update) %>

--- a/app/views/trestle/resource/new.html.erb
+++ b/app/views/trestle/resource/new.html.erb
@@ -1,7 +1,7 @@
 <% title = t("admin.titles.new", default: "New %{model_name}", model_name: admin.model_name.titleize, pluralized_model_name: admin.model_name.plural.titleize) %>
 
 <% content_for(:title, title) %>
-<% breadcrumb title %>
+<% breadcrumb(title) %>
 
 <% content_for(:primary_toolbar) do %>
   <%= button_tag t("admin.buttons.save", default: "Save %{model_name}", model_name: admin.model_name), class: "btn btn-success btn-lg" if admin.actions.include?(:create) %>

--- a/app/views/trestle/resource/show.html.erb
+++ b/app/views/trestle/resource/show.html.erb
@@ -1,7 +1,7 @@
 <% title = t("admin.titles.edit", default: "Editing %{model_name}", model_name: admin.model_name.titleize, pluralized_model_name: admin.model_name.plural.titleize) %>
 
 <% content_for(:title, title) %>
-<% breadcrumb title %>
+<% breadcrumb(title) unless admin.singular? %>
 
 <% content_for(:primary_toolbar) do %>
   <%= button_tag t("admin.buttons.save", default: "Save %{model_name}", model_name: admin.model_name), class: "btn btn-success btn-lg" if admin.actions.include?(:update) %>

--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -69,12 +69,16 @@ module Trestle
         "#{name.underscore}/admin"
       end
 
-      def path(action=:index, options={})
+      def path(action=root_action, options={})
         Engine.routes.url_for(options.merge(controller: controller_namespace, action: action, only_path: true))
       end
 
       def actions
         [:index]
+      end
+
+      def root_action
+        :index
       end
 
       def routes

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -99,8 +99,16 @@ module Trestle
         @actions ||= (readonly? ? READONLY_ACTIONS : RESOURCE_ACTIONS).dup
       end
 
+      def root_action
+        singular? ? :show : :index
+      end
+
       def readonly?
         options[:readonly]
+      end
+
+      def singular?
+        options[:singular]
       end
 
       def instance_path(instance, options={})
@@ -111,8 +119,17 @@ module Trestle
       def routes
         admin = self
 
+        resource_method  = singular? ? :resource : :resources
+        resource_name    = admin_name
+        resource_options = {
+          controller: controller_namespace,
+          as:         route_name,
+          path:       options[:path],
+          except:     (RESOURCE_ACTIONS - actions)
+        }
+
         Proc.new do
-          resources admin.admin_name, controller: admin.controller_namespace, as: admin.route_name, path: admin.options[:path], except: (RESOURCE_ACTIONS - admin.actions) do
+          public_send(resource_method, resource_name, resource_options) do
             instance_exec(&admin.additional_routes) if admin.additional_routes
           end
         end

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -113,7 +113,9 @@ module Trestle
 
       def instance_path(instance, options={})
         action = options.fetch(:action) { :show }
-        path(action, options.merge(id: to_param(instance)))
+        options = options.merge(id: to_param(instance)) unless singular?
+
+        path(action, options)
       end
 
       def routes

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -143,6 +143,12 @@ module Trestle
         Resource::Builder.build(self, &block)
       end
 
+      def validate!
+        if singular? && find_instance_block.nil?
+          raise NotImplementedError, "Singular resources must define an instance block."
+        end
+      end
+
     private
       def infer_model_class
         parent.const_get(admin_name.classify)

--- a/lib/trestle/resource/controller.rb
+++ b/lib/trestle/resource/controller.rb
@@ -44,10 +44,18 @@ module Trestle
       end
 
       def show
-        respond_to do |format|
-          format.html
-          format.json { render json: instance }
-          format.js
+        if admin.singular? && instance.nil?
+          respond_to do |format|
+            format.html { redirect_to action: :new }
+            format.json { head :not_found }
+            format.js
+          end
+        else
+          respond_to do |format|
+            format.html
+            format.json { render json: instance }
+            format.js
+          end
         end
       end
 

--- a/spec/trestle/resource_spec.rb
+++ b/spec/trestle/resource_spec.rb
@@ -48,25 +48,6 @@ describe Trestle::Resource do
     expect(admin.breadcrumbs).to eq(trail)
   end
 
-  context "scoped within a module" do
-    before(:each) do
-      module Scoped
-        class Test; end
-        class TestAdmin < Trestle::Resource; end
-      end
-    end
-
-    after(:each) do
-      Scoped.send(:remove_const, :TestAdmin)
-    end
-
-    subject(:admin) { Scoped::TestAdmin }
-
-    it "infers the model from the module and admin name" do
-      expect(admin.model).to eq(Scoped::Test)
-    end
-  end
-
   it "has a default collection block" do
     class Test; end
     expect(Test).to receive(:all).and_return([1, 2, 3])
@@ -132,6 +113,54 @@ describe Trestle::Resource do
           expect(admin.prepare_collection(sort: "field", order: "desc")).to eq(sorted_collection)
         end
       end
+    end
+  end
+
+  context "scoped within a module" do
+    before(:each) do
+      module Scoped
+        class Test; end
+        class TestAdmin < Trestle::Resource; end
+      end
+    end
+
+    after(:each) do
+      Scoped.send(:remove_const, :TestAdmin)
+    end
+
+    subject(:admin) { Scoped::TestAdmin }
+
+    it "infers the model from the module and admin name" do
+      expect(admin.model).to eq(Scoped::Test)
+    end
+  end
+
+  context "a singular resource" do
+    before(:each) do
+      Trestle.resource(:singular, singular: true) do
+        instance {}
+      end
+    end
+
+    after(:each) do
+      Object.send(:remove_const, :SingularAdmin)
+    end
+
+    subject(:admin) { SingularAdmin }
+
+    it "is singular" do
+      expect(admin).to be_singular
+    end
+
+    it "returns the show action path as the default path" do
+      Rails.application.reload_routes!
+      expect(admin.path).to eq("/admin/singular")
+    end
+
+    it "raises an exception if an instance block is not defined" do
+      expect {
+        Trestle.resource(:singular, singular: true)
+      }.to raise_error(NotImplementedError, "Singular resources must define an instance block.")
     end
   end
 end


### PR DESCRIPTION
Building on the work that @spohlenz has started to finish up implementation of singular resources. This will address #109 

The main difference between regular and singular resources is the lack of an index view for singular resources. You go straight to editing or creating a new instance from the sidebar.

- [x] Special breadcrumbs for singular resources (Home / Account rather than Home / Accounts / Editing account)
- [x] Require the `instance` block for singular resources and redirect to the new action if the instance is nil
- [x] Handle pathing for singular instance