### PR TITLE
Pass params hash to delete_instance block

### DIFF
--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -21,7 +21,7 @@ module Trestle
         instance.save
       end
 
-      def delete_instance(instance)
+      def delete_instance(instance, params={})
         instance.destroy
       end
 

--- a/lib/trestle/adapters/adapter.rb
+++ b/lib/trestle/adapters/adapter.rb
@@ -56,9 +56,10 @@ module Trestle
       # Deletes an instance (used by the destroy action).
       #
       # instance - The instance to delete
+      # params   - Unfiltered params hash from the controller
       #
       # Returns a boolean indicating the success/fail status of the deletion.
-      def delete_instance(instance)
+      def delete_instance(instance, params={})
         raise NotImplementedError
       end
 

--- a/lib/trestle/adapters/sequel_adapter.rb
+++ b/lib/trestle/adapters/sequel_adapter.rb
@@ -30,7 +30,7 @@ module Trestle
         instance.save
       end
 
-      def delete_instance(instance)
+      def delete_instance(instance, params={})
         instance.destroy
       end
 

--- a/lib/trestle/resource/controller.rb
+++ b/lib/trestle/resource/controller.rb
@@ -90,7 +90,7 @@ module Trestle
       end
 
       def destroy
-        success = admin.delete_instance(instance)
+        success = admin.delete_instance(instance, params)
 
         respond_to do |format|
           format.html do

--- a/spec/trestle/resource/builder_spec.rb
+++ b/spec/trestle/resource/builder_spec.rb
@@ -172,13 +172,13 @@ describe Trestle::Resource::Builder, remove_const: true do
       instance = double
 
       Trestle::Resource::Builder.create(:tests) do
-        delete_instance do |instance|
-          repository.delete(instance)
+        delete_instance do |instance, params|
+          repository.delete(instance, params)
         end
       end
 
-      expect(repository).to receive(:delete).with(instance)
-      expect(::TestsAdmin.delete_instance(instance))
+      expect(repository).to receive(:delete).with(instance, name: "Test")
+      expect(::TestsAdmin.delete_instance(instance, name: "Test"))
     end
   end
 


### PR DESCRIPTION
Hi, I need access to params when destroying a resource.

The use case is to allow administrators to decide if they want to sent a notification via email.

```rb
Trestle.resource(:reservations, model: Reservation) do
  delete_instance do |instance, params|
    CancelReservation.new(instance, params[:send_notification]).call
  end
end
```

Do you think it's good to add this to the project?

P.D.: Thank you for this good library