### PR TITLE
Allow creating static fields without a value

### DIFF
--- a/lib/trestle/form/fields/static_field.rb
+++ b/lib/trestle/form/fields/static_field.rb
@@ -10,6 +10,7 @@ module Trestle
           else
             @value = value
           end
+          @value ||= builder.object.send(name) if builder.object
 
           super(builder, template, name, options, &block)
         end

--- a/spec/trestle/form/builder_spec.rb
+++ b/spec/trestle/form/builder_spec.rb
@@ -15,6 +15,37 @@ describe Trestle::Form::Builder, type: :helper do
 
   subject(:builder) { Trestle::Form::Builder.new(object_name, object, template, options) }
 
+  describe '#static_field' do
+    it 'renders when only a field name is provided' do
+      result = builder.static_field(:title)
+
+      expect(result).to have_tag('.form-group') do
+        with_tag "label.control-label", text: "Title", without: { class: "sr-only" }
+        with_tag "p", text: object.title
+      end
+    end
+
+    it 'renders when a value is provided' do
+      value = 'A Title'
+      result = builder.static_field(:title, value)
+
+      expect(result).to have_tag('.form-group') do
+        with_tag "label.control-label", text: "Title", without: { class: "sr-only" }
+        with_tag "p", text: value
+      end
+    end
+
+    it 'renders when a block is provided' do
+      value = 'A Title'
+      result = builder.static_field(:title) { content_tag(:span, value) }
+
+      expect(result).to have_tag('.form-group') do
+        with_tag "label.control-label", text: "Title", without: { class: "sr-only" }
+        with_tag "span", text: value
+      end
+    end
+  end
+
   describe "#text_field" do
     it "renders the field with a label within a form group" do
       result = builder.text_field(:title)


### PR DESCRIPTION
This allows easier static fields. Instead of:

```ruby
static_field :attr, obj.attr
```

You can use it just like `text_field` & other types, by simply supplying the attribute name:

```ruby
text_field :attr1
static_field :attr2
```