### PR TITLE
Using collection.count(:all) in the ActiveRecord adapter

### DIFF
--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -30,7 +30,7 @@ module Trestle
       end
 
       def count(collection)
-        collection.count
+        collection.count(:all)
       end
 
       def sort(collection, field, order)


### PR DESCRIPTION
TL;DR
-----

This PR changes `collection.count` to `collection.count(:all)` in the ActiveRecord adapter to prevent an ambiguous column error in the `COUNT` query of a resource scope when it uses `select+joins`.

Motivation
----------

Let's start by defining a basic resource.

```ruby
Trestle.resource :articles do
  collection do
    Article
      .select(:id, :title)
      .joins(:author)
      .where(authors: { visible: true })
  end

  scope :all, default: true
  scope :published, -> { collection.where(published: true) }
end
```

This looks like a reasonable resource but will cause an SQL error regarding an ambiguous 'id' column.

This is due to the `COUNT` query that is sent to provide the number of items for a given scope.

The generated query will look something like this:

```sql
SELECT COUNT(id, title)
FROM "articles"
INNER JOIN "authors" ON "authors"."id" = "articles"."author_id"
WHERE "authors"."visible" = TRUE;
```

Since the `COUNT` contains non-prefixed column names the `id` column will indeed be ambiguous.

_I'd argue that it's an ActiveRecord issue but fixing it is far more complicated than what this PR does._

Solution
--------

The solution this PR proposes is to explicitly ask for a `COUNT(*)` query, avoiding the issue entirely.

Note
----

I didn't write any test as I didn't find a location to do so and I didn't felt entitled to decide how and where to add new specs. I'd be happy to write a spec for it though.