### PR TITLE
Pass html_options through to navigation items

### DIFF
--- a/app/views/trestle/shared/_sidebar.html.erb
+++ b/app/views/trestle/shared/_sidebar.html.erb
@@ -20,7 +20,7 @@
 
           <% items.each do |item| %>
             <li<% if current_navigation_item?(item) %> class="active"<% end %>>
-              <%= link_to item.path do %>
+              <%= link_to item.path, item.html_options do %>
                 <%= icon("nav-icon", item.icon) %>
                 <span class="nav-label"><%= item.label %></span>
 

--- a/lib/trestle/navigation/item.rb
+++ b/lib/trestle/navigation/item.rb
@@ -55,6 +55,10 @@ module Trestle
         Badge.new(options[:badge]) if badge?
       end
 
+      def html_options
+        options.except(:admin, :badge, :group, :icon, :if, :label, :priority, :unless)
+      end
+
       def visible?(context)
         if options[:if]
           context.instance_exec(&options[:if])

--- a/spec/trestle/navigation/item_spec.rb
+++ b/spec/trestle/navigation/item_spec.rb
@@ -60,6 +60,11 @@ describe Trestle::Navigation::Item do
     expect(item.visible?(self)).to be false
   end
 
+  it "can set html_options" do
+    item = Trestle::Navigation::Item.new(:test, nil, icon: "fa", class: "text-danger")
+    expect(item.html_options).to eq({ class: "text-danger" })
+  end
+
   context "with a badge" do
     it "has a badge" do
       item = Trestle::Navigation::Item.new(:test, nil, badge: { text: "123", class: "badge-success" })


### PR DESCRIPTION
This is important when adding external links to the sidebar navigation. When navigating to pages that don't support turbolinks (like background job processing web interfaces), we need to add `data-turbolinks="false"`. This makes that possible.

```ruby
config.menu do
  item 'Background Jobs', '/admin/que', data: { turbolinks: false }, icon: 'fa fa-cogs', priority: :last
end
```