### PR TITLE
Center logo on mobile

### DIFF
--- a/frontend/css/layout/_sidebar.scss
+++ b/frontend/css/layout/_sidebar.scss
@@ -155,7 +155,7 @@
 
   .app-sidebar-title {
     justify-content: center;
-    margin-right: 65px;
+    margin-right: 49.44px;
     padding: 10px 5px;
   }
 


### PR DESCRIPTION
I'm not sure why this margin is set to `65px`. The navbar toggler seems to be `39.44px` with a `10px` left margin which means this value needs to be `49.44px` for the logo to be centered.
<img width="207" alt="Screen Shot 2020-02-03 at 4 17 53 PM" src="https://user-images.githubusercontent.com/157270/73702293-30c33580-46a1-11ea-946e-c8426e9cb1cf.png">
<img width="262" alt="Screen Shot 2020-02-03 at 4 18 34 PM" src="https://user-images.githubusercontent.com/157270/73702295-33be2600-46a1-11ea-809e-db53c1a35a55.png">
