### PR TITLE
Update README.md with link to trestle-omniauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following plugins are currently available:
 | *trestle-sidekiq* | [Sidekiq](http://sidekiq.org/) integration | [GitHub](https://github.com/TrestleAdmin/trestle-sidekiq) \| [RubyGems](https://rubygems.org/gems/trestle-sidekiq) |
 | *trestle-active_storage* | [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) integration | [GitHub](https://github.com/richardvenneman/trestle-active_storage) \| [RubyGems](https://rubygems.org/gems/trestle-active_storage) |
 | *trestle-mobility* | [Mobility](https://github.com/shioyama/mobility) integration | [GitHub](https://github.com/richardvenneman/trestle-mobility) \| [RubyGems](https://rubygems.org/gems/trestle-mobility) |
+| *trestle-omniauth* | OmniAuth authentication plugin | [GitHub](https://github.com/airhorns/trestle-omniauth) \| [RubyGems](https://rubygems.org/gems/trestle-omniauth) |
 
 
 ## License


### PR DESCRIPTION
I authored and have been using `trestle-omniauth` for authenticating into various Trestle admins using various single sign on providers, like `omniauth-google-oauth2` and whatnot. If you already have GSuite or something set up for your admin users, it's handy to not have to maintain another account! `trestle-omniauth` is implemented similarly to `trestle-auth` and adds a `config.omniauth` to Trestle's config allowing adding omniauth providers.

I think others might want to do the same so I figured it'd be good to make it a bit more discoverable by adding it to the main Trestle readme. `trestle-omniauth` is pretty fresh however, and I think I'm really the only user, so if it's too early for this tacit endorsement I totally understand!

Thanks for a productive piece of software! 