### PR TITLE
Fix Ruby 2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 
 rvm:
   - 2.6.5
+  - 2.7.1
 
 gemfile:
   - gemfiles/rails-5.0.gemfile

--- a/app/views/trestle/table/_pagination.html.erb
+++ b/app/views/trestle/table/_pagination.html.erb
@@ -1,5 +1,5 @@
 <nav class="pagination-container">
   <p><%= page_entries_info(collection, entry_name: (entry_name if local_assigns.has_key?(:entry_name))) %>
 
-  <%= paginate(collection, { theme: "trestle" }.reverse_merge(local_assigns.has_key?(:options) ? options : {})) %>
+  <%= paginate(collection, **{ theme: "trestle" }.reverse_merge(local_assigns.has_key?(:options) ? options : {})) %>
 </nav>

--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -90,7 +90,7 @@ module Trestle
         defaults = [:"admin.#{i18n_key}.#{key}", :"admin.#{key}"]
         defaults << options[:default] if options[:default]
 
-        I18n.t(defaults.shift, options.merge(default: defaults))
+        I18n.t(defaults.shift, **options.merge(default: defaults))
       end
       alias t translate
 

--- a/lib/trestle/hook/helpers.rb
+++ b/lib/trestle/hook/helpers.rb
@@ -1,7 +1,7 @@
 module Trestle
   class Hook
     module Helpers
-      def hook(name, *args)
+      def hook(name, *args, &block)
         hooks = hooks(name)
 
         if hooks.any?
@@ -9,7 +9,7 @@ module Trestle
             hook.evaluate(self, *args)
           }, "\n")
         elsif block_given?
-          capture(*args, &Proc.new)
+          capture(*args, &block)
         end
       end
 


### PR DESCRIPTION
This PR fixes all deprecation warnings seen with Ruby 2.7 and adds testing against Ruby 2.7 on Travis.