### PR TITLE
test on CI with eager loading

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -7,10 +7,14 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  if ENV["CI"] || ENV["TEST_EAGER_LOAD"]
+    config.eager_load = true
+  else
+    # Do not eager load code on boot. This avoids loading your whole application
+    # just for the purpose of running a single test. If you are using a tool that
+    # preloads Rails for running tests, you may have to set it to true.
+    config.eager_load = false
+  end
 
   # Configure public file server for tests with Cache-Control for performance.
   if config.respond_to?(:public_file_server)

--- a/spec/trestle/resource/builder_spec.rb
+++ b/spec/trestle/resource/builder_spec.rb
@@ -29,7 +29,7 @@ describe Trestle::Resource::Builder, remove_const: true do
     expect(Trestle::ResourceController).not_to be(Trestle::AdminController)
 
     ActiveSupport::Dependencies.mechanism = :require
-  end unless Rails.configuration.try(:autoloader) == :zeitwerk
+  end unless (Rails.application.config.eager_load || Rails.configuration.try(:autoloader) == :zeitwerk)
 
   describe "#table" do
     it "builds an index table with the admin and sortable options set" do


### PR DESCRIPTION
this sets `eager_load` on CI, as it's more like production (and theoretically will catch loading gotchas better).

but locally keeps it  `eager_load` to false it's a bit of a pain as it's slower to first spec.

UPDATE: had to remove one autoloading/reloading test when eager_load is on (as it won't work and messes up following specs )