### PR TITLE
Ensure sidebar is ordered alphabetically even in zeitwerk loading

### DIFF
--- a/lib/trestle/registry.rb
+++ b/lib/trestle/registry.rb
@@ -10,7 +10,7 @@ module Trestle
     end
 
     def each(&block)
-      @admins.values.each(&block)
+      @admins.values.sort_by(&:admin_name).each(&block)
     end
 
     def reset!

--- a/spec/feature/navigation_spec.rb
+++ b/spec/feature/navigation_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+feature 'Navigation' do
+
+  before do
+    # NB zeitwerk can eager-load files in arbitrary order
+    # https://github.com/fxn/zeitwerk/issues/92#issuecomment-543834270
+    #  -- simulating here
+    # (also note that manually reloading is required in order for there to be any in sidebar at all)
+    %w[PostsAdmin DialogAdmin AutomaticAdmin ScopesAdmin].each do |class_name|
+      Object.send(:remove_const, class_name) if Object.const_defined?(class_name)
+      load(Rails.root.join("app/admin/#{class_name.underscore}.rb"))
+    end
+  end
+
+  scenario 'Sidebar lists resources in alphabetic order (not random order)' do
+    visit '/admin/scopes'
+    got_texts = page.all(".app-sidebar-inner .app-nav ul li").map(&:text)
+    expected_texts = %w[Automatic Dialog Posts Scopes]
+    expect(got_texts).to contain_exactly(*expected_texts) # <- this is fine
+    expect(got_texts).to eq(expected_texts) # <- this is problematic
+  end
+end

--- a/spec/trestle/registry_spec.rb
+++ b/spec/trestle/registry_spec.rb
@@ -19,6 +19,18 @@ describe Trestle::Registry, remove_const: true do
     end
   end
 
+  describe "enumeration" do
+    let(:first_admin) { double(admin_name: "a-test") }
+    let(:last_admin) { double(admin_name: "z-test") }
+
+    it "provides them in alphabetical order no matter how they are added" do
+      registry.register(admin)
+      registry.register(last_admin)
+      registry.register(first_admin)
+      expect(registry.map(&:admin_name)).to eq(["a-test", "test", "z-test"])
+    end
+  end
+
   describe "#reset!" do
     it "clears out the registry" do
       registry.register(admin)


### PR DESCRIPTION
Zeitwerk eager loading loads admin classes in an arbitrary order (whereas classic loading loads in alphabetical order) -- see #350.

This fixes this by sorting on iteration (however a better fix might be to fix on addition, given that this happens only once).

Fixes #350