### PR TITLE
Add display_methods to trestle.rb.erb template

### DIFF
--- a/lib/generators/trestle/install/templates/trestle.rb.erb
+++ b/lib/generators/trestle/install/templates/trestle.rb.erb
@@ -119,6 +119,10 @@ Trestle.configure do |config|
   # end
   #
   # config.form_field :custom, CustomFormField
+  #
+  # List of methods to try calling on an instance when displayed by the `display` helper
+  # config.display_methods = [:display_name, :full_name, :name, :title, :username, :login, :email]
+  #
 
   # == Debugging Options
   #


### PR DESCRIPTION
Added the display_methods config to the trestle.rb template so it is easier to override by the user.