### PR TITLE
Sort I18n.available_locales

### DIFF
--- a/app/assets/javascripts/trestle/i18n.js.erb
+++ b/app/assets/javascripts/trestle/i18n.js.erb
@@ -1,6 +1,6 @@
 <% flatpickr_locale_conversions = { ca: "cat", el: "gr", nb: "no", vi: "vn" } %>
 
-<% I18n.available_locales.each do |locale| %>
+<% I18n.available_locales.sort.each do |locale| %>
   <% Trestle.i18n_fallbacks(locale).each do |candidate| %>
     <% candidate = flatpickr_locale_conversions[candidate] || candidate %>
     <% require_asset("trestle/flatpickr/#{candidate}") rescue nil %>


### PR DESCRIPTION
We ran into an unexpected issue that different machines return `I18n.available_locales` in different order. Did not find out the root cause.

The impact was the digest used in the view is different from the one in the filename.

In case anyone runs into the same issue, this should fix it.