### PR TITLE
Ruby 3.0 compatibility

### DIFF
--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -9,9 +9,9 @@ module Trestle
     end
 
     # Delegate all missing methods to corresponding class method if available
-    def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       if self.class.respond_to?(name)
-        self.class.send(name, *args, &block)
+        self.class.send(name, *args, **kwargs, &block)
       else
         super
       end

--- a/lib/trestle/evaluation_context.rb
+++ b/lib/trestle/evaluation_context.rb
@@ -5,16 +5,13 @@ module Trestle
   # both the Adapter/Navigation instance, as well as the controller/view from where they are invoked.
   module EvaluationContext
   protected
-    def self.ruby2_keywords(*)
-    end unless respond_to?(:ruby2_keywords, true)
-
     # Missing methods are called on the given context if available.
     #
     # We include private methods as methods such as current_user
     # are usually declared as private or protected.
-    ruby2_keywords def method_missing(name, *args, &block)
+    def method_missing(name, *args, **kwargs, &block)
       if context_responds_to?(name)
-        @context.send(name, *args, &block)
+        @context.send(name, *args, **kwargs, &block)
       else
         super
       end

--- a/lib/trestle/form/builder.rb
+++ b/lib/trestle/form/builder.rb
@@ -29,9 +29,9 @@ module Trestle
         self.class.fields.has_key?(name) || super
       end
 
-      def method_missing(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
         if field = self.class.fields[name]
-          field.new(self, @template, *args, &block).render
+          field.new(self, @template, *args, **kwargs, &block).render
         else
           super
         end

--- a/lib/trestle/form/renderer.rb
+++ b/lib/trestle/form/renderer.rb
@@ -4,9 +4,6 @@ require "action_view/helpers"
 module Trestle
   class Form
     class Renderer
-      def self.ruby2_keywords(*)
-      end unless respond_to?(:ruby2_keywords, true)
-
       include ::ActionView::Context
       include ::ActionView::Helpers::CaptureHelper
 
@@ -43,15 +40,15 @@ module Trestle
         concat(result)
       end
 
-      ruby2_keywords def method_missing(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
         target = @form.respond_to?(name) ? @form : @template
 
         if block_given? && !RAW_BLOCK_HELPERS.include?(name)
-          result = target.send(name, *args) do |*blockargs|
-            render_form(*blockargs, &block)
+          result = target.send(name, *args, **kwargs) do |*blockargs, **kwblockargs|
+            render_form(*blockargs, **kwblockargs &block)
           end
         else
-          result = target.send(name, *args, &block)
+          result = target.send(name, *args, **kwargs, &block)
         end
 
         if target == @form || WHITELISTED_HELPERS.include?(name)

--- a/lib/trestle/toolbar/context.rb
+++ b/lib/trestle/toolbar/context.rb
@@ -25,8 +25,8 @@ module Trestle
         builder.respond_to?(name) || super
       end
 
-      def method_missing(name, *args, &block)
-        result = builder.send(name, *args, &block)
+      def method_missing(name, *args, **kwargs, &block)
+        result = builder.send(name, *args, **kwargs, &block)
 
         if builder.builder_methods.include?(name)
           group { @current_group << result }


### PR DESCRIPTION
We had issues updating to Ruby 3.0 in our project. This has been caused by the new Ruby 3.0 keyword argument handling, where passing a hash as positional argument does not automatically convert its contents to keyword arguments anymore, leading to ArgumentErrors of the form "Unexpected number of arguments, expected 2, got 3".

This PR therefore explicitly forwards keyword-arguments as well as positional arguments in `method_missing` definitions.

I'm not really sure about the `ruby2_keywords`-changes in this PR, whether removing those is neccessary/advisable or not...

I'm also unsure whether all other usages of `*args` need to be adjusted by also adding `**kwargs`...