### PR TITLE
Ordering items of equal priority by name

### DIFF
--- a/lib/trestle/navigation/item.rb
+++ b/lib/trestle/navigation/item.rb
@@ -17,7 +17,7 @@ module Trestle
       end
 
       def <=>(other)
-        priority <=> other.priority
+        priority == other.priority ? name <=> other.name : priority <=> other.priority
       end
 
       def priority


### PR DESCRIPTION
When two navigation items have the same priority, it can result in random ordering, at least in development.

This PR orders them by name in case of equal priority so that the order is always the same.