### PR TITLE
Support latest haml version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ group :test do
   gem 'coveralls_reborn', require: false
   gem 'guard-rspec',      require: false
 
-  gem 'capybara'
+  gem 'capybara', github: 'teamcapybara/capybara', ref: '2d05c20'
   gem 'capybara-selenium'
   gem 'rexml'
   gem 'selenium-webdriver'
   gem 'webdrivers'
-  gem 'puma'
+  gem 'puma', '~> 6.0.0'
   gem 'launchy'
   gem 'capybara-screenshot'
 end

--- a/lib/trestle/table/column.rb
+++ b/lib/trestle/table/column.rb
@@ -108,25 +108,12 @@ module Trestle
 
         def column_value(instance)
           if @column.block
-            if defined?(Haml) && Haml::Helpers.block_is_haml?(@column.block)
-              # In order for table column blocks to work properly within Haml templates,
-              # the _hamlout local variable needs to be defined in the scope of the block,
-              # so that the Haml version of the capture method is used. Because we
-              # evaluate the block using instance_exec, we need to set this up manually.
-              -> {
-                _hamlout = eval('_hamlout', @column.block.binding)
-                value = nil
-                buffer = @template.capture { value = @template.instance_exec(instance, &@column.block) }
-                value.is_a?(String) ? buffer : value
-              }.call
-            else
-              # Capture both the immediate value and captured output of the block.
-              # If the result of the block is a string, then use the contents of the buffer.
-              # Otherwise return the result of the block as a raw value (for auto-formatting).
-              value = nil
-              buffer = @template.capture { value = @template.instance_exec(instance, &@column.block) }
-              value.is_a?(String) ? buffer : value
-            end
+            # Capture both the immediate value and captured output of the block.
+            # If the result of the block is a string, then use the contents of the buffer.
+            # Otherwise return the result of the block as a raw value (for auto-formatting).
+            value = nil
+            buffer = @template.capture { value = @template.instance_exec(instance, &@column.block) }
+	    value.is_a?(String) ? buffer : value
           else
             instance.send(@column.field)
           end


### PR DESCRIPTION
This change allows haml templates to be used in trestle (specifically the `trestle/table/table` template being rendered from within a custom haml template. The new version of HAML is a complete re-write, that removed the `Haml::Helpers.block_is_haml?` method. 

I'm not quite sure how to write a repro test case, but this last `render` line produced an undefined method error that is gone when I remove the bit of code:

```
= render layout: "layout" do
  .main-content-container
    .main-content
      - if hook?("resource.index.header")
        %header.main-content-header
          = hook("resource.index.header")
      = render "trestle/table/table", table: admin.table, collection: collection
```

AFAICS the template is rendering as it should without said line.

I've also pinned a capybara version that will allow specs to pass correctly with the latest version of Puma, this can be removed when capybara has a new release.