### PR TITLE
Ensure menu items with sym/str names can be sorted

### DIFF
--- a/lib/trestle/navigation/item.rb
+++ b/lib/trestle/navigation/item.rb
@@ -4,7 +4,7 @@ module Trestle
       attr_reader :name, :path, :options
 
       def initialize(name, path=nil, options={})
-        @name, @path, @options = name, path, options
+        @name, @path, @options = name.to_s, path, options
       end
 
       def ==(other)
@@ -40,7 +40,7 @@ module Trestle
       end
 
       def label
-        options[:label] || I18n.t("admin.navigation.items.#{name}", default: name.to_s.titlecase)
+        options[:label] || I18n.t("admin.navigation.items.#{name}", default: name.titlecase)
       end
 
       def icon

--- a/spec/trestle/navigation/item_spec.rb
+++ b/spec/trestle/navigation/item_spec.rb
@@ -54,6 +54,14 @@ describe Trestle::Navigation::Item do
     expect([i3, i1, i2].sort).to eq([i1, i2, i3])
   end
 
+  it "sorts with string and symbol names" do
+    i1 = Trestle::Navigation::Item.new(:test1)
+    i2 = Trestle::Navigation::Item.new("test2")
+    i3 = Trestle::Navigation::Item.new(:test3)
+
+    expect([i3, i1, i2].sort).to eq([i1, i2, i3])
+  end
+
   it "is visible by default" do
     expect(item.visible?(self)).to be true
   end


### PR DESCRIPTION
Hello - I recently updated a few gems locally in one of my apps (including Trestle 0.9.5 to 0.9.7), and for some reason this broke Trestle pages in the app, with a fairly cryptic error:

<img width="1054" alt="Screenshot 2022-12-16 at 15 21 48" src="https://user-images.githubusercontent.com/43235608/208131043-8d621167-0248-455b-a035-d248079fa54f.png">
<img width="725" alt="Screenshot 2022-12-16 at 15 21 52" src="https://user-images.githubusercontent.com/43235608/208131047-6ac8344f-7f07-4418-9238-4caf6f4c241c.png">

After a lot of digging, I realised it was because some of our menu items had their names defined as symbols (eg `:blog_posts`), and some as strings (`"Longer name written as string"`), so because `Menu::Item#<=>` looks at the `name`, and because `:symbol <=> "string"` returns nil, this was breaking the sorting (but coming from quite a deep place).

It's quite a simple fix, but happy to share a bit more context if it's helpful!