### PR TITLE
Implement DebugErrors class to unify instance error message access

### DIFF
--- a/app/views/trestle/flash/_flash.html.erb
+++ b/app/views/trestle/flash/_flash.html.erb
@@ -2,6 +2,6 @@
   <%= render "trestle/flash/alert", html_class: "alert-success", icon: icon("alert-icon far fa-check-circle"), alert: normalize_flash_alert(flash[:message]) %>
 <% elsif flash[:error] -%>
   <%= render layout: "trestle/flash/alert", locals: { html_class: "alert-danger", icon: icon("alert-icon far fa-times-circle"), alert: normalize_flash_alert(flash[:error]) } do %>
-    <%= render "trestle/flash/debug", errors: instance.errors if debug_form_errors? %>
+    <%= render "trestle/flash/debug", errors: Trestle::DebugErrors.new(instance.errors) if debug_form_errors? %>
   <% end %>
 <% end -%>

--- a/lib/trestle.rb
+++ b/lib/trestle.rb
@@ -11,6 +11,7 @@ module Trestle
   require_relative "trestle/adapters"
   require_relative "trestle/attribute"
   require_relative "trestle/breadcrumb"
+  require_relative "trestle/debug_errors"
   require_relative "trestle/lazy"
   require_relative "trestle/configurable"
   require_relative "trestle/configuration"

--- a/lib/trestle/debug_errors.rb
+++ b/lib/trestle/debug_errors.rb
@@ -1,0 +1,22 @@
+module Trestle
+  class DebugErrors
+    def initialize(errors)
+      @errors = errors
+    end
+
+    def any?
+      @errors.any?
+    end
+
+    def each
+      @errors.each { |error, message|
+        if defined?(ActiveModel::Error)
+          # Rails 6.1 introduces a unified Error class
+          yield error.attribute, error.message
+        else
+          yield error, message
+        end
+      }
+    end
+  end
+end

--- a/lib/trestle/debug_errors.rb
+++ b/lib/trestle/debug_errors.rb
@@ -9,14 +9,16 @@ module Trestle
     end
 
     def each
-      @errors.each { |error, message|
-        if defined?(ActiveModel::Error)
-          # Rails 6.1 introduces a unified Error class
+      if defined?(ActiveModel::Error)
+        # Rails 6.1 introduces a unified Error class
+        @errors.each do |error|
           yield error.attribute, error.message
-        else
+        end
+      else
+        @errors.each do |error, message|
           yield error, message
         end
-      }
+      end
     end
   end
 end

--- a/spec/trestle/debug_errors_spec.rb
+++ b/spec/trestle/debug_errors_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Trestle::DebugErrors do
+  class MyClass
+    extend ActiveModel::Naming
+
+    def initialize
+      @attrs = { attribute: "abc", another: 123 }
+    end
+
+    def read_attribute_for_validation(attr)
+      @attrs[attr]
+    end
+
+    def self.human_attribute_name(attr, options = {})
+      attr
+    end
+  end
+
+  let(:instance) { MyClass.new }
+  let(:errors) { ActiveModel::Errors.new(instance) }
+
+  subject(:debug_errors) { Trestle::DebugErrors.new(errors) }
+
+  describe "#any?" do
+    it "returns false if there are no errors" do
+      expect(errors.any?).to be false
+    end
+
+    it "returns true if there are errors" do
+      errors.add(:attribute, :invalid)
+      expect(errors.any?).to be true
+    end
+  end
+
+  describe "#each" do
+    it "iterates over each error yielding the attribute and message" do
+      errors.add(:attribute, :invalid)
+      errors.add(:attribute, :taken)
+      errors.add(:another, :invalid)
+
+      expect { |b| debug_errors.each(&b) }.to yield_successive_args(
+        [:attribute, "is invalid"],
+        [:attribute, "has already been taken"],
+        [:another, "is invalid"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Rails 6.1 introduces a unified `ActiveModel::Error` class, and deprecates the two-variable yielding when calling `errors#each`.