### PR TITLE
When enum defined in Rails6 model with Int8 and mapper in model like:

### DIFF
--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -89,8 +89,8 @@ module Trestle
       end
 
       def enum_values(column)
-        model.defined_enums[column.name].map { |key, value|
-          [value, enum_human_name(column, key)]
+        model.defined_enums[column.name].map { |key, _value|
+          [key, enum_human_name(column, key)]
         }
       end
 

--- a/lib/trestle/form/automatic.rb
+++ b/lib/trestle/form/automatic.rb
@@ -33,7 +33,8 @@ module Trestle
               when :boolean
                 check_box attribute.name
               when :enum
-                collection_radio_buttons attribute.name, attribute.options[:values] || [], :first, :last
+                value = instance.has_attribute?(attribute.name) ? instance.public_send(attribute.name.to_sym) : nil
+                collection_radio_buttons(attribute.name, attribute.options[:values] || [], :first, :last, { checked: [value] })
               when :json, :jsonb
                 value = instance.public_send(attribute.name)
                 text_area attribute.name, value: value.try(:to_json)


### PR DESCRIPTION
When enum defined in Rails6 model with Int8 and mapper in model like:
enum kind: { manual: 0, automated: 1, mixed: 2 }, _prefix: true

In this case, the default edit form loses model current value.