### PR TITLE
Clean up usage of ruby2_keywords

### DIFF
--- a/lib/trestle/evaluation_context.rb
+++ b/lib/trestle/evaluation_context.rb
@@ -5,20 +5,18 @@ module Trestle
   # both the Adapter/Navigation instance, as well as the controller/view from where they are invoked.
   module EvaluationContext
   protected
-    def self.ruby2_keywords(*)
-    end unless respond_to?(:ruby2_keywords, true)
-
     # Missing methods are called on the given context if available.
     #
     # We include private methods as methods such as current_user
     # are usually declared as private or protected.
-    ruby2_keywords def method_missing(name, *args, &block)
+    def method_missing(name, *args, &block)
       if context_responds_to?(name)
         @context.send(name, *args, &block)
       else
         super
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def respond_to_missing?(name, include_private=false)
       context_responds_to?(name) || super

--- a/lib/trestle/form/renderer.rb
+++ b/lib/trestle/form/renderer.rb
@@ -4,9 +4,6 @@ require "action_view/helpers"
 module Trestle
   class Form
     class Renderer
-      def self.ruby2_keywords(*)
-      end unless respond_to?(:ruby2_keywords, true)
-
       include ::ActionView::Context
       include ::ActionView::Helpers::CaptureHelper
 
@@ -46,7 +43,7 @@ module Trestle
         concat(result)
       end
 
-      ruby2_keywords def method_missing(name, *args, &block)
+      def method_missing(name, *args, &block)
         target = @form.respond_to?(name) ? @form : @template
 
         if block_given? && !RAW_BLOCK_HELPERS.include?(name)
@@ -63,6 +60,7 @@ module Trestle
           result
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(name, include_all=false)
         @form.respond_to?(name, include_all) ||

--- a/lib/trestle/toolbar/context.rb
+++ b/lib/trestle/toolbar/context.rb
@@ -21,10 +21,7 @@ module Trestle
       end
 
     private
-      def self.ruby2_keywords(*)
-      end unless respond_to?(:ruby2_keywords, true)
-
-      ruby2_keywords def method_missing(name, *args, &block)
+      def method_missing(name, *args, &block)
         result = builder.send(name, *args, &block)
 
         if builder.builder_methods.include?(name)
@@ -33,6 +30,7 @@ module Trestle
           result
         end
       end
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
       def respond_to_missing?(name, include_all=false)
         builder.respond_to?(name) || super


### PR DESCRIPTION
Cleaner use of ruby2_keywords using advice from https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html. Avoids unnecessary method definition if not required.