### PR TITLE
Support Rails 8.0 routes

### DIFF
--- a/lib/trestle/engine.rb
+++ b/lib/trestle/engine.rb
@@ -17,7 +17,7 @@ module Trestle
     initializer "trestle.automount" do |app|
       if Trestle.config.automount
         app.routes.prepend do
-          mount Trestle::Engine => Trestle.config.path
+          mount Trestle::Engine, at: Trestle.config.path
         end
       end
     end

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -133,7 +133,7 @@ module Trestle
         }
 
         Proc.new do
-          public_send(resource_method, resource_name, resource_options) do
+          public_send(resource_method, resource_name, **resource_options) do
             admin.additional_routes.each do |block|
               instance_exec(&block)
             end


### PR DESCRIPTION
When using Rails 8 (main branch checkout), there are a bunch of errors (kwargs) and deprecation warnings, because Rails deprecates Routes.rb ``post :something => 'action'``, arrow functions because of performance optim [PR](https://github.com/rails/rails/pull/52422)

Here is the diff, that fixes it for me.

As Rails8 is not released, it would be best, to wait to merge this until beta-releases, in case they change anything about this feature, or new deprecations occur.

In the meantime, other people can use my branch:

```
 gem 'trestle', git: 'https://github.com/zealot128-os/trestle.git', branch: 'rails8'
```