### PR TITLE
Depend on turbo-rails from GitHub in Rails 8.0 Gemfiles

### DIFF
--- a/gemfiles/rails-8.0-propshaft.gemfile
+++ b/gemfiles/rails-8.0-propshaft.gemfile
@@ -20,6 +20,7 @@ group :test do
 end
 
 gem 'rails', github: 'rails/rails'
+gem 'turbo-rails', github: 'hotwired/turbo-rails'
 gem 'propshaft'
 gem 'sqlite3'
 

--- a/gemfiles/rails-8.0.gemfile
+++ b/gemfiles/rails-8.0.gemfile
@@ -20,6 +20,7 @@ group :test do
 end
 
 gem 'rails', github: 'rails/rails'
+gem 'turbo-rails', github: 'hotwired/turbo-rails'
 gem 'sprockets-rails'
 gem 'sqlite3'
 


### PR DESCRIPTION
This can be reverted once hotwired/turbo-rails#657 makes its way into a gem release.