### PR TITLE
Document and clean up helper modules

### DIFF
--- a/app/helpers/trestle/avatar_helper.rb
+++ b/app/helpers/trestle/avatar_helper.rb
@@ -1,10 +1,8 @@
 module Trestle
   module AvatarHelper
-    def avatar(options={})
-      fallback = options.delete(:fallback) if options[:fallback]
-
-      content_tag(:div, default_avatar_options.merge(options)) do
-        concat content_tag(:span, fallback, class: "avatar-fallback") if fallback
+    def avatar(fallback: nil, **attributes)
+      tag.div(**default_avatar_options.merge(attributes)) do
+        concat tag.span(fallback, class: "avatar-fallback") if fallback
         concat yield if block_given?
       end
     end

--- a/app/helpers/trestle/avatar_helper.rb
+++ b/app/helpers/trestle/avatar_helper.rb
@@ -7,15 +7,7 @@ module Trestle
       end
     end
 
-    def gravatar(email, options={})
-      options = { d: "mp" }.merge(options)
-
-      url = "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.to_s.downcase)}.png"
-      url << "?#{options.to_query}" if options.any?
-
-      image_tag(url)
-    end
-
+  protected
     def default_avatar_options
       Trestle::Options.new(class: ["avatar"])
     end

--- a/app/helpers/trestle/avatar_helper.rb
+++ b/app/helpers/trestle/avatar_helper.rb
@@ -1,6 +1,22 @@
 module Trestle
   module AvatarHelper
-    def avatar(fallback: nil, **attributes)
+    # Renders an avatar (or similar image) styled as a circle typically designed to
+    # represent a user (though not limited to that). The avatar helper accepts a block
+    # within which the image should be provided, which will be resized to fit.
+    #
+    # fallback   - Optional short text (2-3 characters) shown when no image is available
+    # attributes - Additional HTML attributes to add to the <div> tag
+    #
+    # Examples
+    #
+    #   <%= avatar { image_tag("person.jpg") } %>
+    #
+    #   <%= avatar(fallback: "SP", class: "avatar-lg") { gravatar("sam@trestle.io") } %>
+    #
+    #   <%= avatar(style: "--avatar-size: 3rem") { gravatar("sam@trestle.io") }
+    #
+    # Return the HTML div containing the avatar image.
+    def avatar(fallback: nil, **attributes, &block)
       tag.div(**default_avatar_options.merge(attributes)) do
         concat tag.span(fallback, class: "avatar-fallback") if fallback
         concat yield if block_given?

--- a/app/helpers/trestle/card_helper.rb
+++ b/app/helpers/trestle/card_helper.rb
@@ -1,20 +1,38 @@
 module Trestle
   module CardHelper
+    # Renders a card container element (sometimes also known as a panel or well), based on
+    # Bootstrap's card element (https://getbootstrap.com/docs/5.3/components/card/).
+    #
+    # header     - Optional header to add within a .card-header
+    # footer     - Optional footer to add within a .card-footer
+    # attributes - Additional HTML attributes to add to the container <div> tag
+    #
+    # Examples
+    #
+    # <%= card do %>
+    #   <p>Card content here...</p>
+    # <% end %>
+    #
+    # <%= card header: "Header", footer: "Footer", class: "text-bg-primary" do %>...
+    #
+    # Returns a HTML-safe String.
     def card(header: nil, footer: nil, **attributes, &block)
       tag.div(**attributes.merge(class: ["card", attributes[:class]])) do
         safe_join([
-          (tag.div(header, class: "card-header") if header),
+          (tag.header(header, class: "card-header") if header),
           tag.div(class: "card-body", &block),
-          (tag.div(footer, class: "card-footer") if footer)
+          (tag.footer(footer, class: "card-footer") if footer)
         ].compact)
       end
     end
 
+    # [DEPRECATED] Alias for card
     def panel(**attributes, &block)
       Trestle.deprecator.warn("The panel helper is deprecated and will be removed in future versions of Trestle. Please use the card helper instead.")
       card(**attributes.merge(header: attributes[:title]), &block)
     end
 
+    # [DEPRECATED] Alias for card
     def well(**attributes, &block)
       Trestle.deprecator.warn("The well helper is deprecated and will be removed in future versions of Trestle. Please use the card helper instead.")
       card(**attributes, &block)

--- a/app/helpers/trestle/card_helper.rb
+++ b/app/helpers/trestle/card_helper.rb
@@ -1,23 +1,23 @@
 module Trestle
   module CardHelper
-    def card(options={}, &block)
-      tag.div(options.slice(:id, :data).merge(class: ["card", options[:class]].compact)) do
+    def card(header: nil, footer: nil, **attributes, &block)
+      tag.div(**attributes.merge(class: ["card", attributes[:class]])) do
         safe_join([
-          (tag.div(options[:header], class: "card-header") if options[:header]),
+          (tag.div(header, class: "card-header") if header),
           tag.div(class: "card-body", &block),
-          (tag.div(options[:footer], class: "card-footer") if options[:footer])
+          (tag.div(footer, class: "card-footer") if footer)
         ].compact)
       end
     end
 
-    def panel(options={}, &block)
+    def panel(**attributes, &block)
       Trestle.deprecator.warn("The panel helper is deprecated and will be removed in future versions of Trestle. Please use the card helper instead.")
-      card(options.merge(header: options[:title]), &block)
+      card(**attributes.merge(header: attributes[:title]), &block)
     end
 
-    def well(options={}, &block)
+    def well(**attributes, &block)
       Trestle.deprecator.warn("The well helper is deprecated and will be removed in future versions of Trestle. Please use the card helper instead.")
-      card(options, &block)
+      card(**attributes, &block)
     end
   end
 end

--- a/app/helpers/trestle/card_helper.rb
+++ b/app/helpers/trestle/card_helper.rb
@@ -1,11 +1,11 @@
 module Trestle
   module CardHelper
     def card(options={}, &block)
-      content_tag(:div, options.slice(:id, :data).merge(class: ["card", options[:class]].compact)) do
+      tag.div(options.slice(:id, :data).merge(class: ["card", options[:class]].compact)) do
         safe_join([
-          (content_tag(:div, options[:header], class: "card-header") if options[:header]),
-          content_tag(:div, class: "card-body", &block),
-          (content_tag(:div, options[:footer], class: "card-footer") if options[:footer])
+          (tag.div(options[:header], class: "card-header") if options[:header]),
+          tag.div(class: "card-body", &block),
+          (tag.div(options[:footer], class: "card-footer") if options[:footer])
         ].compact)
       end
     end

--- a/app/helpers/trestle/container_helper.rb
+++ b/app/helpers/trestle/container_helper.rb
@@ -4,8 +4,8 @@ module Trestle
       context = Context.new(self)
       content = capture(context, &block)
 
-      content_tag(:div, class: "main-content-container") do
-        concat content_tag(:div, content, class: "main-content")
+      tag.div(class: "main-content-container") do
+        concat tag.div(content, class: "main-content")
         concat context.sidebar if context.sidebar
       end
     end
@@ -17,7 +17,7 @@ module Trestle
 
       def sidebar(options={}, &block)
         if block_given?
-          @sidebar = @template.content_tag(:aside, default_sidebar_options.merge(options), &block)
+          @sidebar = @template.tag.aside(**default_sidebar_options.merge(options), &block)
           nil
         else
           @sidebar

--- a/app/helpers/trestle/container_helper.rb
+++ b/app/helpers/trestle/container_helper.rb
@@ -1,10 +1,33 @@
 module Trestle
   module ContainerHelper
-    def container(&block)
+    # Renders a content container with an optional sidebar, which can
+    # be useful when creating an admin or dashboard with a custom view.
+    #
+    # This helper accepts a block (within which the main content is provided),
+    # which yields a `Context` capture object. The Context object has one important
+    # method -- `sidebar(**attributes, &block)` which renders a sidebar.
+    #
+    # attributes - Additional HTML attributes to add to the <div> tag
+    #
+    # Examples
+    #
+    #   <%= container do |c| %>
+    #     This content will be wrapped in a .main-content-container > .main-content div.
+    #   <% end %>
+    #
+    #   <%= container do |c| %>
+    #     <% c.sidebar class: "order-first" %>
+    #       Sidebar content...
+    #     <% end %>
+    #     Main content...
+    #   <% end %>
+    #
+    # Returns a HTML-safe String.
+    def container(**attributes, &block)
       context = Context.new(self)
-      content = capture(context, &block)
+      content = capture(context, &block) if block_given?
 
-      tag.div(class: "main-content-container") do
+      tag.div(**attributes.merge(class: ["main-content-container", attributes[:class]])) do
         concat tag.div(content, class: "main-content")
         concat context.sidebar if context.sidebar
       end
@@ -15,15 +38,22 @@ module Trestle
         @template = template
       end
 
-      def sidebar(options={}, &block)
+      # Captures or renders the sidebar for a container block.
+      #
+      # When passed a block, the block content is captured as the sidebar content, and nil is returned.
+      # When no block is provided, the sidebar tag is returned (if defined).
+      #
+      # attributes - Additional HTML attributes to add to the <div> tag
+      def sidebar(**attributes, &block)
         if block_given?
-          @sidebar = @template.tag.aside(**default_sidebar_options.merge(options), &block)
+          @sidebar = @template.tag.aside(**default_sidebar_options.merge(attributes), &block)
           nil
         else
           @sidebar
         end
       end
 
+    protected
       def default_sidebar_options
         Trestle::Options.new(class: ["main-content-sidebar"])
       end

--- a/app/helpers/trestle/container_helper.rb
+++ b/app/helpers/trestle/container_helper.rb
@@ -5,7 +5,8 @@ module Trestle
     #
     # This helper accepts a block (within which the main content is provided),
     # which yields a `Context` capture object. The Context object has one important
-    # method -- `sidebar(**attributes, &block)` which renders a sidebar.
+    # method -- `sidebar(**attributes, &block)` which captures the sidebar content
+    # to be rendered after the main content.
     #
     # attributes - Additional HTML attributes to add to the <div> tag
     #

--- a/app/helpers/trestle/display_helper.rb
+++ b/app/helpers/trestle/display_helper.rb
@@ -1,5 +1,16 @@
 module Trestle
   module DisplayHelper
+    # Returns a plain-text representation of the given model instance,
+    # typically used when rendering an associated object within a table.
+    #
+    # This helper delegates to Trestle::Display, which works by checking the
+    # existence of each method from `Trestle.config.display_methods` in turn
+    # and calling the first one it finds.
+    #
+    # By default this list is set to:
+    #
+    #   [:display_name, :full_name, :name, :title, :username, :login, :email]
+    #
     def display(instance)
       Trestle::Display.new(instance).to_s
     end

--- a/app/helpers/trestle/flash_helper.rb
+++ b/app/helpers/trestle/flash_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module FlashHelper
     def normalize_flash_alert(flash)
       flash.is_a?(Hash) ? flash.with_indifferent_access : { message: flash }

--- a/app/helpers/trestle/flash_helper.rb
+++ b/app/helpers/trestle/flash_helper.rb
@@ -11,15 +11,5 @@ module Trestle
     def instance_has_errors?
       instance.errors.any? rescue false
     end
-
-    def turbo_stream_update_flash
-      <<-EOF
-      <turbo-stream action="update" target="flash">
-        <template>
-          #{render_to_string(partial: "trestle/flash/flash", formats: [:html])}
-        </template>
-      </turbo-stream>
-      EOF
-    end
   end
 end

--- a/app/helpers/trestle/form_helper.rb
+++ b/app/helpers/trestle/form_helper.rb
@@ -1,6 +1,5 @@
 module Trestle
   module FormHelper
-    IDENTITY_FIELD_ERROR_PROC = Proc.new { |html_tag, instance| html_tag }
     DEFAULT_FORM_CONTROLLERS = %w(keyboard-submit form-loading form-error)
 
     def trestle_form_for(instance, options={}, &block)
@@ -17,12 +16,19 @@ module Trestle
       end
     end
 
+    def form
+      @_trestle_form
+    end
+
+  protected
     def with_form(form)
       @_trestle_form = form
       yield form if block_given?
     ensure
       @_trestle_form = nil
     end
+
+    IDENTITY_FIELD_ERROR_PROC = Proc.new { |html_tag, instance| html_tag }
 
     def with_identity_field_error_proc
       original_field_error_proc = ::ActionView::Base.field_error_proc
@@ -31,18 +37,6 @@ module Trestle
       yield if block_given?
     ensure
       ::ActionView::Base.field_error_proc = original_field_error_proc
-    end
-
-    def form
-      @_trestle_form
-    end
-
-    def sidebar(&block)
-      content_for(:sidebar, &block)
-    end
-
-    def render_sidebar_as_tab?
-      modal_request? && content_for?(:sidebar)
     end
   end
 end

--- a/app/helpers/trestle/form_helper.rb
+++ b/app/helpers/trestle/form_helper.rb
@@ -2,20 +2,41 @@ module Trestle
   module FormHelper
     DEFAULT_FORM_CONTROLLERS = %w(keyboard-submit form-loading form-error)
 
-    def trestle_form_for(instance, options={}, &block)
+    # Generates a form for a resource using Rails' #form_for helper.
+    #
+    # In addition to delegating to #form_for, this helper method:
+    #
+    # 1) Sets the default form builder to `Trestle::Form::Builder`.
+    # 2) Sets the default :as option to match the parameter name
+    #    expected by the admin.
+    # 3) Sets default Stimulus controllers on the <form> element:
+    #    "keyboard-submit form-loading form-error"
+    # 4) Sets a null/identity ActionView::Base.field_error_proc as
+    #    errors are handled by Trestle::Form::Fields::FormGroup.
+    # 5) Exposes the yielded form builder instance via the `form` helper.
+    #
+    # Examples
+    #
+    #   <%= trestle_form_for(article, url: admin.instance_path(instance, action: :update),
+    #                                 method: :patch) do %> ...
+    #
+    # Returns a HTML-safe String. Yields the form builder instance.
+    def trestle_form_for(instance, **options, &block)
       options[:builder] ||= Form::Builder
       options[:as] ||= admin.parameter_name
 
       options[:data] ||= {}
       options[:data][:controller] = (DEFAULT_FORM_CONTROLLERS + Array(options[:data][:controller])).join(" ")
 
-      form_for(instance, options) do |f|
+      form_for(instance, **options) do |f|
         with_identity_field_error_proc do
           with_form(f) { yield f }
         end
       end
     end
 
+    # Returns the currently scoped Trestle form builder
+    # (a subclass of ActionView::Helpers::FormBuilder).
     def form
       @_trestle_form
     end

--- a/app/helpers/trestle/format_helper.rb
+++ b/app/helpers/trestle/format_helper.rb
@@ -1,5 +1,29 @@
 module Trestle
   module FormatHelper
+    # Formats a value, either with an explicit format (given the :format option)
+    # or automatically based on its type using the `autoformat_value` helper.
+    #
+    # This helper is most commonly called when rendering content within a
+    # table cell, but is available to use from any view context.
+    #
+    # value   - Value to format
+    # format  - Symbol representing format type. Currently supported:
+    #           :auto, nil - Auto-formats (default)
+    #           :currency - Formats as currency using `number_to_currency`
+    #           :tags - Formats an array of Strings as a tag list
+    # options - Options hash to pass to `autoformat_value` helper
+    #
+    # Examples
+    #
+    #   <%= format_value(123.45, format: :currency) %>
+    #   <%= format_value(article.tags, format: :tags) %>
+    #
+    #   <%= format_value(Time.current) %>
+    #   <%= format_value(nil, blank: "None") %>
+    #   <%= format_value(true) %>
+    #
+    # Returns a HTML-safe String.
+    # Raises ArgumentError if an invalid format is given.
     def format_value(value, format: :auto, **options)
       case format
       when :auto, nil
@@ -14,6 +38,18 @@ module Trestle
       end
     end
 
+    # Auto-formats a value based on its type.
+    #
+    # The current implementation of this helper supports Arrays, Time/Datetime,
+    # Date, true/false values, nil, String (with optional truncation) or model
+    # instance types (using the `display` helper).
+    #
+    # value   - Value to format (multiple types supported)
+    # options - Options hash, usage dependent on value type. Currently supported:
+    #           :blank    - text to display for nil values (e.g. "N/A")
+    #           :truncate - passed to truncate helper for String values
+    #
+    # Returns a HTML-safe String.
     def autoformat_value(value, **options)
       case value
       when Array

--- a/app/helpers/trestle/format_helper.rb
+++ b/app/helpers/trestle/format_helper.rb
@@ -13,8 +13,8 @@ module Trestle
       when :currency
         number_to_currency(value)
       when :tags
-        tags = Array(value).map { |tag| content_tag(:span, tag, class: "tag tag-primary") }
-        content_tag(:div, safe_join(tags), class: "tag-list")
+        tags = Array(value).map { |t| tag.span(t, class: "tag tag-primary") }
+        tag.div(safe_join(tags), class: "tag-list")
       else
         value
       end
@@ -23,8 +23,8 @@ module Trestle
     def autoformat_value(value, options={})
       case value
       when Array
-        content_tag(:ol, safe_join(value.map { |v|
-          content_tag(:li, v.is_a?(Array) ? v : autoformat_value(v, options)) },
+        tag.ol(safe_join(value.map { |v|
+          tag.li(v.is_a?(Array) ? v : autoformat_value(v, options)) },
         "\n"))
       when Time, DateTime
         timestamp(value)
@@ -37,7 +37,7 @@ module Trestle
         if blank.respond_to?(:call)
           instance_exec(&blank)
         else
-          content_tag(:span, blank, class: "blank")
+          tag.span(blank, class: "blank")
         end
       when String
         if value.html_safe? || options[:truncate] == false

--- a/app/helpers/trestle/format_helper.rb
+++ b/app/helpers/trestle/format_helper.rb
@@ -1,30 +1,24 @@
 module Trestle
   module FormatHelper
-    def format_value(value, options={})
-      if options.key?(:format)
-        format_value_from_options(value, options)
-      else
-        autoformat_value(value, options)
-      end
-    end
-
-    def format_value_from_options(value, options={})
-      case options[:format]
+    def format_value(value, format: :auto, **options)
+      case format
+      when :auto, nil
+        autoformat_value(value, **options)
       when :currency
         number_to_currency(value)
       when :tags
         tags = Array(value).map { |t| tag.span(t, class: "tag tag-primary") }
         tag.div(safe_join(tags), class: "tag-list")
       else
-        value
+        raise ArgumentError, "unknown format: #{format}"
       end
     end
 
-    def autoformat_value(value, options={})
+    def autoformat_value(value, **options)
       case value
       when Array
         tag.ol(safe_join(value.map { |v|
-          tag.li(v.is_a?(Array) ? v : autoformat_value(v, options)) },
+          tag.li(v.is_a?(Array) ? v : autoformat_value(v, **options)) },
         "\n"))
       when Time, DateTime
         timestamp(value)

--- a/app/helpers/trestle/gravatar_helper.rb
+++ b/app/helpers/trestle/gravatar_helper.rb
@@ -1,0 +1,21 @@
+module Trestle
+  module GravatarHelper
+    def gravatar_image_tag(email, **options)
+      image_tag(gravatar_image_url(email, **options))
+    end
+    alias gravatar gravatar_image_tag
+
+    def gravatar_image_url(email, **options)
+      options = default_gravatar_options.merge(options)
+
+      url = "https://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(email.to_s.downcase)}.png"
+      url << "?#{options.to_query}" if options.any?
+      url
+    end
+
+  protected
+    def default_gravatar_options
+      { d: "mp" }
+    end
+  end
+end

--- a/app/helpers/trestle/gravatar_helper.rb
+++ b/app/helpers/trestle/gravatar_helper.rb
@@ -1,10 +1,37 @@
 module Trestle
   module GravatarHelper
+    # Returns a Gravatar image tag for a given email address.
+    # See https://docs.gravatar.com/api/avatars/images/ for available options.
+    #
+    # In general, this should be wrapped in an avatar block to apply styling.
+    # This method is also aliased as `gravatar`.
+    #
+    # email   - Email address for Gravatar image; will be MD5-hashed to create the URL
+    # options - Options to pass to Gravatar API (as query string params)
+    #
+    # Examples
+    #
+    # <%= avatar { gravatar_image_tag("sam@trestle.io") } %>
+    #
+    # <%= avatar { gravatar_image_tag("sam@trestle.io", size: 120, d: "retro") } %>
+    #
+    # Returns a HTML-safe String.
     def gravatar_image_tag(email, **options)
       image_tag(gravatar_image_url(email, **options))
     end
     alias gravatar gravatar_image_tag
 
+    # Returns a Gravatar image URL for a given email address.
+    # See https://docs.gravatar.com/api/avatars/images/ for available options.
+    #
+    # email   - Email address for Gravatar image; will be MD5-hashed to create the URL
+    # options - Options to pass to Gravatar API (as query string params)
+    #
+    # Example
+    #
+    # <%= gravatar_image_url("sam@trestle.io", size: 120, d: "retro") %>
+    #
+    # Returns a HTML-safe String.
     def gravatar_image_url(email, **options)
       options = default_gravatar_options.merge(options)
 

--- a/app/helpers/trestle/grid_helper.rb
+++ b/app/helpers/trestle/grid_helper.rb
@@ -1,9 +1,9 @@
 module Trestle
   module GridHelper
     # Renders a row div, one of the building blocks of Bootstrap's grid system.
-    # https://getbootstrap.com/docs/4.4/layout/grid/
+    # https://getbootstrap.com/docs/5.3/layout/grid/
     #
-    # attrs - Hash of attributes that will be passed to the tag (e.g. id, data, class).
+    # attributes - Hash of attributes that will be passed to the tag (e.g. id, data, class)
     #
     # Examples
     #
@@ -20,7 +20,7 @@ module Trestle
     end
 
     # Renders a column div, one of the building blocks of Bootstrap's grid system.
-    # https://getbootstrap.com/docs/4.4/layout/grid/
+    # https://getbootstrap.com/docs/5.3/layout/grid/
     #
     # Column divs should always be rendered inside of a row div.
     #
@@ -56,7 +56,7 @@ module Trestle
 
     # Renders an <HR> (horizontal rule) HTML tag.
     #
-    # attrs - Hash of attributes that will be passed to the tag (e.g. id, data, class).
+    # attributes - Hash of attributes that will be passed to the tag (e.g. id, data, class)
     #
     # Returns a HTML-safe String.
     def divider(**attributes)

--- a/app/helpers/trestle/grid_helper.rb
+++ b/app/helpers/trestle/grid_helper.rb
@@ -14,11 +14,9 @@ module Trestle
     #   <%= row class: "row-cols-2", id: "my-row" do %> ...
     #
     # Returns a HTML-safe String.
-    def row(attrs={})
+    def row(**attributes)
       defaults = Trestle::Options.new(class: ["row"])
-      options = defaults.merge(attrs)
-
-      content_tag(:div, options) { yield }
+      tag.div(**defaults.merge(attributes)) { yield }
     end
 
     # Renders a column div, one of the building blocks of Bootstrap's grid system.
@@ -53,7 +51,7 @@ module Trestle
         classes += breakpoints.map { |breakpoint, span| "col-#{breakpoint}-#{span}" }
       end
 
-      content_tag(:div, class: classes) { yield }
+      tag.div(class: classes) { yield }
     end
 
     # Renders an <HR> (horizontal rule) HTML tag.
@@ -61,8 +59,8 @@ module Trestle
     # attrs - Hash of attributes that will be passed to the tag (e.g. id, data, class).
     #
     # Returns a HTML-safe String.
-    def divider(attrs={})
-      tag(:hr, attrs)
+    def divider(**attributes)
+      tag.hr(**attributes)
     end
   end
 end

--- a/app/helpers/trestle/grid_helper.rb
+++ b/app/helpers/trestle/grid_helper.rb
@@ -1,6 +1,6 @@
 module Trestle
   module GridHelper
-    # Renders a row div, one of the building blocks of Bootstrap's grid system.
+    # Renders a row <div> tag, one of the building blocks of Bootstrap's grid system.
     # https://getbootstrap.com/docs/5.3/layout/grid/
     #
     # attributes - Hash of attributes that will be passed to the tag (e.g. id, data, class)
@@ -19,7 +19,7 @@ module Trestle
       tag.div(**defaults.merge(attributes)) { yield }
     end
 
-    # Renders a column div, one of the building blocks of Bootstrap's grid system.
+    # Renders a column <div> tag, one of the building blocks of Bootstrap's grid system.
     # https://getbootstrap.com/docs/5.3/layout/grid/
     #
     # Column divs should always be rendered inside of a row div.
@@ -54,9 +54,9 @@ module Trestle
       tag.div(class: classes) { yield }
     end
 
-    # Renders an <HR> (horizontal rule) HTML tag.
+    # Renders an <hr> (horizontal rule) HTML tag.
     #
-    # attributes - Hash of attributes that will be passed to the tag (e.g. id, data, class)
+    # attributes - Hash of attributes that will be passed to the <hr> tag
     #
     # Returns a HTML-safe String.
     def divider(**attributes)

--- a/app/helpers/trestle/headings_helper.rb
+++ b/app/helpers/trestle/headings_helper.rb
@@ -1,5 +1,6 @@
 module Trestle
   module HeadingsHelper
+    # These methods are delegated to the ActionView::Helpers::TagHelper proxy object for convenience.
     delegate :h1, :h2, :h3, :h4, :h5, :h6, to: :tag
   end
 end

--- a/app/helpers/trestle/headings_helper.rb
+++ b/app/helpers/trestle/headings_helper.rb
@@ -1,27 +1,5 @@
 module Trestle
   module HeadingsHelper
-    def h1(text, options={})
-      content_tag(:h1, text, options)
-    end
-
-    def h2(text, options={})
-      content_tag(:h2, text, options)
-    end
-
-    def h3(text, options={})
-      content_tag(:h3, text, options)
-    end
-
-    def h4(text, options={})
-      content_tag(:h4, text, options)
-    end
-
-    def h5(text, options={})
-      content_tag(:h5, text, options)
-    end
-
-    def h6(text, options={})
-      content_tag(:h6, text, options)
-    end
+    delegate :h1, :h2, :h3, :h4, :h5, :h6, to: :tag
   end
 end

--- a/app/helpers/trestle/i18n_helper.rb
+++ b/app/helpers/trestle/i18n_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module I18nHelper
     FLATPICKR_LOCALE_CONVERSIONS = { ca: "cat", el: "gr", nb: "no", vi: "vn" }.stringify_keys
 

--- a/app/helpers/trestle/icon_helper.rb
+++ b/app/helpers/trestle/icon_helper.rb
@@ -1,8 +1,7 @@
 module Trestle
   module IconHelper
-    def icon(*classes)
-      options = classes.extract_options!
-      content_tag(:i, "", options.merge(class: classes))
+    def icon(*classes, **attributes)
+      tag.i("", **attributes.merge(class: [*classes, attributes[:class]]))
     end
   end
 end

--- a/app/helpers/trestle/icon_helper.rb
+++ b/app/helpers/trestle/icon_helper.rb
@@ -1,5 +1,19 @@
 module Trestle
   module IconHelper
+    # Renders an icon (as an <i> tag).
+    #
+    # Trestle includes the FontAwesome icon library but other font
+    # libraries can be included via custom CSS.
+    #
+    # classes    - List of font name classes to add to the <i> tag
+    # attributes - Additional HTML attributes to add to the <i> tag
+    #
+    # Examples
+    #
+    #   <%= icon("fas fa-star") %>
+    #   <%= icon("fas", "fa-star", class: "fa-fw text-muted")
+    #
+    # Return the HTML i tag for the icon.
     def icon(*classes, **attributes)
       tag.i("", **attributes.merge(class: [*classes, attributes[:class]]))
     end

--- a/app/helpers/trestle/layout_helper.rb
+++ b/app/helpers/trestle/layout_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module LayoutHelper
     SIDEBAR_CLASSES = {
       "expanded"  => "sidebar-expanded",

--- a/app/helpers/trestle/modal_helper.rb
+++ b/app/helpers/trestle/modal_helper.rb
@@ -1,16 +1,34 @@
 module Trestle
   module ModalHelper
+    # Merges the given options with the existing hash of defined modal options.
+    #
+    # Trestle uses Bootstrap modal markup (https://getbootstrap.com/docs/5.3/components/modal/)
+    # to render modals, which consist of an outer .modal wrapper div with an inner
+    # .modal-dialog div.
+    #
+    # The `class` attribute (e.g. `"modal-lg"`) is applied to the inner element, and all
+    # other attributes are applied to the outer element. A class can be applied to the
+    # wrapper element using the `wrapper_class` option.
+    #
+    # Examples
+    #
+    #   <% modal_options! class: "modal-lg", controller: "modal-stimulus" %>
+    #
+    #   <% modal_options! wrapper_class: "custom-modal-animation" %>
+    #
     def modal_options!(options)
       modal_options.merge!(options)
     end
 
+    # Returns a hash of the currently defined modal options
     def modal_options
       @_modal_options ||= {}
     end
 
+    # Returns the HTML attributes to apply to the modal wrapper (.modal) <div>
     def modal_wrapper_attributes
       {
-        class: ["modal", "fade", modal_options[:wrapper_class]],
+        class: ["modal", "fade", modal_options[:wrapper_class]].compact,
         tabindex: "-1",
         role: "dialog",
         data: {
@@ -19,9 +37,10 @@ module Trestle
       }.deep_merge(modal_options.except(:class, :wrapper_class, :controller))
     end
 
+    # Returns the HTML attributes to apply to the inner modal dialog (.modal-dialog) <div>
     def modal_dialog_attributes
       {
-        class: ["modal-dialog", modal_options[:class]],
+        class: ["modal-dialog", modal_options[:class]].compact,
         role: "document"
       }
     end

--- a/app/helpers/trestle/navigation_helper.rb
+++ b/app/helpers/trestle/navigation_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module NavigationHelper
     def current_navigation_item?(item)
       current_page?(item.path) || (item.admin && current_admin?(item.admin))

--- a/app/helpers/trestle/pagination_helper.rb
+++ b/app/helpers/trestle/pagination_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module PaginationHelper
     # Custom version of Kaminari's page_entries_info helper to use a
     # Trestle-scoped I18n key and add a delimiter to the total count.

--- a/app/helpers/trestle/params_helper.rb
+++ b/app/helpers/trestle/params_helper.rb
@@ -1,5 +1,16 @@
 module Trestle
   module ParamsHelper
+    # Returns a subset of the params "hash" (an instance of ActionController::Parameters)
+    # limited to only those keys that should be considered persistent throughout
+    # reordering and pagination.
+    #
+    # This could be a scope or the current order, but this may be extended by Trestle
+    # plugins and the application itself in `Trestle.config.persistent_params` to include
+    # search queries, filters, etc.
+    #
+    # By default this list is set to: [:sort, :order, :scope]
+    #
+    # Returns an instance of ActionController::Parameters.
     def persistent_params
       flat, nested = Trestle.config.persistent_params.partition { |p| !p.is_a?(Hash) }
       nested = nested.inject({}) { |result, param| result.merge(param) }

--- a/app/helpers/trestle/sort_helper.rb
+++ b/app/helpers/trestle/sort_helper.rb
@@ -1,5 +1,30 @@
 module Trestle
   module SortHelper
+    # Renders a sort link for a table column header.
+    #
+    # The `sort` and `order` params are used to determine whether the sort link is
+    # active, and which is the current sort direction (asc or desc). CSS classes are
+    # applied accordingly which are used to render the appropriate icons alongside the link.
+    #
+    # The current set of `persistent_params` is merged with the new `sort`/`order` params
+    # to build the target link URL.
+    #
+    # text    - Text or HTML content to render as the link label
+    # field   - The name of the current field, which should match the `sort` param
+    #           when the collection is being sorted by this field
+    # options - Hash of options (default: {}):
+    #           :default - (Boolean) Set to true if the field is considered to be active
+    #                      even when the `sort` param is blank (default: false)
+    #           :default_order - (String/Symbol) Specify the default collection order when
+    #                            the `order` param is blank (default: "asc")
+    #
+    # Examples
+    #
+    #   <%= sort_link "Title", :title, default: true %>
+    #
+    #   <%= sort_link "Created", :created_at, default_order: "desc" %>
+    #
+    # Returns a HTML-safe String.
     def sort_link(text, field, **options)
       sort_link = SortLink.new(field, persistent_params, **options)
       link_to text, sort_link.params, class: sort_link.classes

--- a/app/helpers/trestle/sort_helper.rb
+++ b/app/helpers/trestle/sort_helper.rb
@@ -1,20 +1,22 @@
 module Trestle
   module SortHelper
-    def sort_link(text, field, options={})
-      sort_link = SortLink.new(field, persistent_params, options)
+    def sort_link(text, field, **options)
+      sort_link = SortLink.new(field, persistent_params, **options)
       link_to text, sort_link.params, class: sort_link.classes
     end
 
     class SortLink
       attr_reader :field
 
-      def initialize(field, params, options)
-        @field, @params, @options = field, params, options
+      def initialize(field, params, default: false, default_order: "asc")
+        @field, @params = field, params
+
+        @default = default
+        @default_order = default_order.to_s
       end
 
       def active?
-        @params[:sort] == field.to_s ||
-          (@options[:default] && !@params.key?(:sort))
+        @params[:sort] == field.to_s || (default? && !@params.key?(:sort))
       end
 
       def params
@@ -33,8 +35,12 @@ module Trestle
         @params[:order] || default_order
       end
 
+      def default?
+        @default
+      end
+
       def default_order
-        @options.fetch(:default_order, "asc").to_s
+        @default_order
       end
 
       def classes

--- a/app/helpers/trestle/status_helper.rb
+++ b/app/helpers/trestle/status_helper.rb
@@ -1,5 +1,22 @@
 module Trestle
   module StatusHelper
+    # Renders a status indicator as a Bootstrap badge.
+    # (https://getbootstrap.com/docs/5.3/components/badge/)
+    #
+    # label      - Status badge text or HTML content
+    # status     - Status class (as .badge-{status}) to apply to the badge (default: :primary)
+    # attributes - Additional HTML attributes to add to the <span> tag
+    #
+    # Examples
+    #
+    #   <%= status_tag("Status Text") %>
+    #
+    #   <%= status_tag(icon("fas fa-check"), :success) %>
+    #
+    #   <%= status_tag(safe_join([icon("fas fa-warning"), "Error"], " "), :danger,
+    #                  data: { controller: "tooltip" }, title: "Full error message") %>
+    #
+    # Returns a HTML-safe String.
     def status_tag(label, status=:primary, **attributes)
       tag.span(label, **attributes.merge(class: ["badge", "badge-#{status}", attributes[:class]]))
     end

--- a/app/helpers/trestle/status_helper.rb
+++ b/app/helpers/trestle/status_helper.rb
@@ -1,8 +1,7 @@
 module Trestle
   module StatusHelper
-    def status_tag(label, status=:primary, options={})
-      options[:class] ||= ["badge", "badge-#{status}"]
-      content_tag(:span, label, options)
+    def status_tag(label, status=:primary, **attributes)
+      tag.span(label, **attributes.merge(class: ["badge", "badge-#{status}", attributes[:class]]))
     end
   end
 end

--- a/app/helpers/trestle/tab_helper.rb
+++ b/app/helpers/trestle/tab_helper.rb
@@ -1,7 +1,7 @@
 module Trestle
   module TabHelper
-    def tab(name, options={})
-      tabs[name] = tab = Tab.new(name, options)
+    def tab(name, **options)
+      tabs[name] = tab = Tab.new(name, **options)
 
       tag.div(id: tab.id(("modal" if modal_request?)), class: ["tab-pane", ('active' if name == tabs.keys.first)], role: "tabpanel") do
         if block_given?

--- a/app/helpers/trestle/tab_helper.rb
+++ b/app/helpers/trestle/tab_helper.rb
@@ -1,5 +1,30 @@
 module Trestle
   module TabHelper
+    # Creates a tab pane using content via the given block, :partial option or partial
+    # template automatically inferred from the tab name.
+    #
+    # It also appends a Trestle::Tab object to the list of declared tabs that is
+    # accessible via the #tabs helper (e.g. for rendering the tab links).
+    #
+    # name    - (Symbol) Internal name for the tab
+    # options - Hash of options (default: {}):
+    #           :label - Optional tab label. If not provided, will be inferred by the
+    #                    admin-translated tab name (`admin.tabs.{name}` i18n scope)
+    #           :badge - Optional badge to show next to the tab label (e.g. a counter)
+    #           :partial - Optional partial template name to use when a block is not provided
+    #
+    # Examples
+    #
+    #   <%= tab :details %>
+    #   => Automatically renders the 'details' partial (e.g. "_details.html.erb") as the tab content
+    #
+    #   <%= tab :metadata, partial: "meta" %>
+    #   => Renders the 'meta' partial (e.g. "_meta.html.erb") as the tab content
+    #
+    #   <%= tab :comments do %> ...
+    #   => Renders the given block as the tab content
+    #
+    # Returns a HTML-safe String.
     def tab(name, **options)
       tabs[name] = tab = Tab.new(name, **options)
 
@@ -14,10 +39,12 @@ module Trestle
       end
     end
 
+    # Returns a hash (name => Trestle::Tab) of the currently declared tabs.
     def tabs
       @_trestle_tabs ||= {}
     end
 
+    # Captures the given block (using `content_for`) as the sidebar content.
     def sidebar(&block)
       content_for(:sidebar, &block)
     end

--- a/app/helpers/trestle/tab_helper.rb
+++ b/app/helpers/trestle/tab_helper.rb
@@ -7,7 +7,7 @@ module Trestle
     def tab(name, options={})
       tabs[name] = tab = Tab.new(name, options)
 
-      content_tag(:div, id: tab.id(("modal" if modal_request?)), class: ["tab-pane", ('active' if name == tabs.keys.first)], role: "tabpanel") do
+      tag.div(id: tab.id(("modal" if modal_request?)), class: ["tab-pane", ('active' if name == tabs.keys.first)], role: "tabpanel") do
         if block_given?
           yield
         elsif options[:partial]

--- a/app/helpers/trestle/tab_helper.rb
+++ b/app/helpers/trestle/tab_helper.rb
@@ -1,9 +1,5 @@
 module Trestle
   module TabHelper
-    def tabs
-      @_trestle_tabs ||= {}
-    end
-
     def tab(name, options={})
       tabs[name] = tab = Tab.new(name, options)
 
@@ -16,6 +12,18 @@ module Trestle
           render partial: name.to_s
         end
       end
+    end
+
+    def tabs
+      @_trestle_tabs ||= {}
+    end
+
+    def sidebar(&block)
+      content_for(:sidebar, &block)
+    end
+
+    def render_sidebar_as_tab?
+      modal_request? && content_for?(:sidebar)
     end
   end
 end

--- a/app/helpers/trestle/table_helper.rb
+++ b/app/helpers/trestle/table_helper.rb
@@ -2,15 +2,17 @@ module Trestle
   module TableHelper
     # Renders an existing named table or builds and renders a custom table if a block is provided.
     #
-    # name    - The (optional) name of the table to render (as a Symbol), or the actual Trestle::Table instance itself.
-    # options - Hash of options that will be passed to the table builder (default: {}):
-    #           :collection - The collection that should be rendered within the table. It should be an
-    #                         Array-like object, but will most likely be an ActiveRecord scope. It can
-    #                         also be a callable object (i.e. a Proc) in which case the result of calling
-    #                         the block will be used as the collection.
-    #           See Trestle::Table::Builder for additional options.
-    # block   - An optional block that is passed to Trestle::Table::Builder to define a custom table.
-    #           One of either the name or block must be provided, but not both.
+    # One of either the name or block must be provided, but not both.
+    #
+    # name       - The (optional) name of the table to render (as a Symbol), or the
+    #              actual Trestle::Table instance itself
+    # collection - The collection that should be rendered within the table.
+    #              It should be an Array-like object, but will most likely be an
+    #              ActiveRecord scope. It can also be a callable object (i.e. a Proc) in
+    #              which case the result of calling the block will be used as the collection
+    # options    - Hash of options that will be passed to the table builder (default: {}).
+    #              See Trestle::Table::Builder for additional options
+    # block      - An optional block that is passed to Trestle::Table::Builder to define a custom table
     #
     # Examples
     #
@@ -23,26 +25,23 @@ module Trestle
     #   <%= table :accounts %>
     #
     # Returns the HTML representation of the table as a HTML-safe String.
-    def table(name=nil, options={}, &block)
+    def table(name=nil, collection: nil, **options, &block)
       if block_given?
-        if name.is_a?(Hash)
-          options = name
-        else
-          collection = name
-        end
-
-        table = Table::Builder.build(options, &block)
+        table = Table::Builder.build(**options, &block)
       else
         if name.is_a?(Trestle::Table)
           table = name
         else
-          table = admin.tables.fetch(name) { raise ArgumentError, "Unable to find table named #{name.inspect}" }
+          table = admin.tables.fetch(name) {
+            raise ArgumentError, "Unable to find table named #{name.inspect}"
+          }
         end
 
-        table = table.with_options(options.reverse_merge(sortable: false))
+        table = table.with_options(sortable: false, **options)
       end
 
-      collection ||= options[:collection] || table.options[:collection]
+      collection ||= name if block_given?
+      collection ||= table.options[:collection]
       collection = collection.call if collection.respond_to?(:call)
 
       render "trestle/table/table", table: table, collection: collection
@@ -50,8 +49,9 @@ module Trestle
 
     # Renders the pagination controls for a collection.
     #
-    # collection - The paginated Kaminari collection to render controls for (required).
-    # options    - Hash of options that will be passed to the Kaminari #paginate method (default: {}):
+    # collection - The paginated Kaminari collection to render controls for (required)
+    # entry_name - Custom item name passed to the Kaminari #page_entries_info helper
+    # options    - Hash of options that will be passed to the Kaminari #paginate method (default: {})
     #
     # Examples
     #

--- a/app/helpers/trestle/timestamp_helper.rb
+++ b/app/helpers/trestle/timestamp_helper.rb
@@ -1,13 +1,13 @@
 module Trestle
   module TimestampHelper
-    # Renders a Time object as a formatted timestamp (using a <time> tag)
+    # Renders a Time object as a formatted timestamp (using a <time> tag).
     #
-    # time    - The Time object to format.
-    # options - Hash of options (default: {}):
-    #           :class       - Additional HTML classes to add to the <time> tag.
-    #           :precision   - Time precision, either :minutes or :seconds (default: :minutes).
-    #           :date_format - I18n date format to use for the date (default: :trestle_date).
-    #           :time_format - I18n time format to use for the time (default: :trestle_time).
+    # time        - The Time object to format
+    # precision   - Time precision, either :minutes or :seconds (default: :minutes)
+    # date_format - I18n date format to use for the date (default: :trestle_date)
+    # time_format - I18n time format to use for the time (default: :trestle_time,
+    #                 or :trestle_time_with_seconds if precision is :seconds)
+    # attributes  - Additional HTML attributes to add to the <time> tag
     #
     # Examples
     #
@@ -16,28 +16,24 @@ module Trestle
     #   <%= timestamp(Time.current, class: "timestamp-inline", precision: :seconds) %>
     #
     # Returns the HTML representation of the given Time.
-    def timestamp(time, options={})
+    def timestamp(time, precision: Trestle.config.timestamp_precision, date_format: :trestle_date, time_format: nil, **attributes)
       return unless time
 
-      classes     = ["timestamp", options[:class]].compact
-      precision   = options.fetch(:precision) { Trestle.config.timestamp_precision }
-      date_format = options.fetch(:date_format) { :trestle_date }
-      time_format = options.fetch(:time_format) { precision == :seconds ? :trestle_time_with_seconds : :trestle_time }
+      time_format ||= (precision == :seconds) ? :trestle_time_with_seconds : :trestle_time
 
-      time_tag(time, class: classes) do
+      time_tag(time, **attributes.merge(class: ["timestamp", attributes[:class]])) do
         safe_join([
-          l(time, format: date_format, default: proc { |date| "#{date.day.ordinalize} %b %Y" }),
+          tag.span(l(time, format: date_format, default: proc { |date| "#{date.day.ordinalize} %b %Y" })),
           tag.small(l(time, format: time_format, default: "%l:%M:%S %p"))
         ], "\n")
       end
     end
 
-    # Renders a Date object as formatted datestamp (using a <time> tag)
+    # Renders a Date object as formatted datestamp (using a <time> tag).
     #
-    # date    - The Date object to format.
-    # options - Hash of options (default: {}):
-    #           :class  - Additional HTML classes to add to the <time> tag.
-    #           :format - I18n date format to use (default: :trestle_calendar).
+    # date       - The Date object to format
+    # format     - I18n date format to use (default: :trestle_calendar)
+    # attributes - Additional HTML attributes to add to the <time> tag
     #
     # Examples
     #
@@ -46,13 +42,10 @@ module Trestle
     #   <%= datestamp(article.created_at, format: :trestle_date, class: "custom-datestamp") %>
     #
     # Returns the HTML representation of the given Date.
-    def datestamp(date, options={})
+    def datestamp(date, format: :trestle_calendar, **attributes)
       return unless date
 
-      classes = ["datestamp", options[:class]].compact
-      format  = options.fetch(:format) { :trestle_calendar}
-
-      time_tag(date, class: classes) do
+      time_tag(date, **attributes.merge(class: ["datestamp", attributes[:class]])) do
         l(date, format: format, default: "%-m/%-d/%Y")
       end
     end

--- a/app/helpers/trestle/timestamp_helper.rb
+++ b/app/helpers/trestle/timestamp_helper.rb
@@ -27,7 +27,7 @@ module Trestle
       time_tag(time, class: classes) do
         safe_join([
           l(time, format: date_format, default: proc { |date| "#{date.day.ordinalize} %b %Y" }),
-          content_tag(:small, l(time, format: time_format, default: "%l:%M:%S %p"))
+          tag.small(l(time, format: time_format, default: "%l:%M:%S %p"))
         ], "\n")
       end
     end

--- a/app/helpers/trestle/title_helper.rb
+++ b/app/helpers/trestle/title_helper.rb
@@ -1,5 +1,7 @@
 module Trestle
   module TitleHelper
+    # Returns the page title (if set using content_for), falling back to
+    # the titleized action name as a default if not set.
     def title
       content_for(:title) || default_title
     end

--- a/app/helpers/trestle/toolbars_helper.rb
+++ b/app/helpers/trestle/toolbars_helper.rb
@@ -1,4 +1,5 @@
 module Trestle
+  # [Internal]
   module ToolbarsHelper
     def render_toolbar(toolbar, *args)
       result = toolbar.groups(self, *args).map do |items|

--- a/app/helpers/trestle/toolbars_helper.rb
+++ b/app/helpers/trestle/toolbars_helper.rb
@@ -3,7 +3,7 @@ module Trestle
     def render_toolbar(toolbar, *args)
       result = toolbar.groups(self, *args).map do |items|
         if items.many?
-          content_tag(:div, class: "btn-group", role: "group") do
+          tag.div(class: "btn-group", role: "group") do
             safe_join(items, "\n")
           end
         else

--- a/app/helpers/trestle/turbo/frame_helper.rb
+++ b/app/helpers/trestle/turbo/frame_helper.rb
@@ -1,7 +1,7 @@
 module Trestle
   module Turbo
     module FrameHelper
-      def index_turbo_frame(options={}, &block)
+      def index_turbo_frame(**attributes, &block)
         defaults = {
           id: "index",
           data: {
@@ -10,10 +10,10 @@ module Trestle
           }
         }
 
-        content_tag("turbo-frame", defaults.merge(options), &block)
+        tag.turbo_frame(**defaults.merge(attributes), &block)
       end
 
-      def resource_turbo_frame(instance, options={}, &block)
+      def resource_turbo_frame(instance, **attributes, &block)
         defaults = {
           id: dom_id(instance),
           target: ("_top" unless modal_request?),
@@ -22,7 +22,7 @@ module Trestle
           }
         }
 
-        content_tag("turbo-frame", defaults.merge(options), &block)
+        tag.turbo_frame(**defaults.merge(attributes), &block)
       end
     end
   end

--- a/app/helpers/trestle/turbo/frame_helper.rb
+++ b/app/helpers/trestle/turbo/frame_helper.rb
@@ -1,6 +1,22 @@
 module Trestle
   module Turbo
     module FrameHelper
+      # Renders a <turbo-frame> container for an index view. An index turbo frame
+      # is by default reloadable (it will be refreshed by the `reload` turbo stream
+      # action), and has the Turbo visit behavior always set to "advance".
+      #
+      # attributes - Additional HTML attributes to add to the <turbo-frame> tag
+      #
+      # Examples
+      #
+      #   <%= index_turbo_frame do %> ...
+      #
+      #   <%= index_turbo_frame id: "articles-index",
+      #                         data: {
+      #                           reloadable_url_value: admin.path(:articles)
+      #                         } do %> ...
+      #
+      # Returns a HTML-safe String.
       def index_turbo_frame(**attributes, &block)
         defaults = {
           id: "index",
@@ -13,6 +29,19 @@ module Trestle
         tag.turbo_frame(**defaults.merge(attributes), &block)
       end
 
+      # Renders a <turbo-frame> container for an instance/resource view. A resource
+      # turbo frame sets its DOM id from the given instance and has a default target of
+      # "_top" (except for modal requests).
+      #
+      # attributes - Additional HTML attributes to add to the <turbo-frame> tag
+      #
+      # Examples
+      #
+      #   <%= resource_turbo_frame(article) do %> ...
+      #
+      #   <%= resource_turbo_frame(article, id: dom_id(article, "comment")) %> ...
+      #
+      # Returns a HTML-safe String.
       def resource_turbo_frame(instance, **attributes, &block)
         defaults = {
           id: dom_id(instance),

--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -60,8 +60,8 @@ module Trestle
       end
     end
 
-    def admin_url_for(instance, options={})
-      admin = Trestle.lookup(options.delete(:admin)) if options.key?(:admin)
+    def admin_url_for(instance, admin: nil, **options)
+      admin = Trestle.lookup(admin) if admin
       admin ||= admin_for(instance)
       return unless admin
 

--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -2,6 +2,36 @@ module Trestle
   module UrlHelper
     MODAL_ACTIONS = [:new, :show, :edit]
 
+    # Generates a link to an admin, optionally for a specific instance on a resourceful admin.
+    #
+    # It has a few additional conveniences over using the standard `link_to` helper:
+    #
+    # 1) It can automatically infer the admin from the given instance.
+    # 2) It will automatically add data-controller="modal-trigger" when linking to a form
+    #    action that is set to show as a modal.
+    # 3) It sets data-turbo-frame appropriately for modal and non-modal contexts to ensure
+    #    the admin can correctly detect modal requests.
+    #
+    # content         - HTML or text content to use as the link content
+    #                   (will be ignored if a block is provided)
+    # instance_or_url - model instance, or explicit String path
+    # options         - Hash of options (default: {})
+    #                   :admin  - Optional explicit admin (symbol or admin class)
+    #                   :action - Controller action to generate the link to
+    #                   :params - Additional params to use when generating the link URL
+    #                   (all other options are forwarded to the `link_to` helper)
+    # block           - Optional block to capture to use as the link content
+    #
+    # Examples
+    #
+    #   <%= admin_link_to article.name, article %>
+    #
+    #   <%= admin_link_to admin: :dashboard, action: :index do %>
+    #     <%= icon "fas fa-gauge" %> Dashboard
+    #   <% end %>
+    #
+    # Returns a HTML-safe String.
+    # Raises ActionController::UrlGenerationError if the admin cannot be automatically inferred.
     def admin_link_to(content, instance_or_url=nil, options={}, &block)
       # Block given - ignore content parameter and capture content from block
       if block_given?
@@ -60,6 +90,21 @@ module Trestle
       end
     end
 
+    # Returns the admin path for a given instance.
+    #
+    # An admin can either be explicitly specified (as a symbol or admin class),
+    # or it can be automatically inferred based the instance type using `admin_for`.
+    #
+    # instance - The model instance to generate a path for
+    # admin    - Optional admin (symbol or admin class)
+    # options  - Hash of options to pass to `instance_path` or `path` admin methods
+    #
+    # Examples
+    #
+    #   <%= admin_url_for(article, action: :edit) %>
+    #   <%= admin_url_for(article, admin: :special_articles) %>
+    #
+    # Returns a String, or nil if the admin cannot be automatically inferred.
     def admin_url_for(instance, admin: nil, **options)
       admin = Trestle.lookup(admin) if admin
       admin ||= admin_for(instance)
@@ -75,6 +120,15 @@ module Trestle
       end
     end
 
+    # Looks up the registered Trestle admin for a given model instance.
+    #
+    # The lookup is performed on the global `Trestle::Registry` instance,
+    # which tracks admin resource models unless the resource was created
+    # with `register_model: false`.
+    #
+    # instance - The model instance to look up in the registry
+    #
+    # Returns a Trestle::Admin subclass or nil if no matching admin found.
     def admin_for(instance)
       Trestle.lookup_model(instance.class)
     end

--- a/lib/trestle/hook/helpers.rb
+++ b/lib/trestle/hook/helpers.rb
@@ -1,6 +1,25 @@
 module Trestle
   class Hook
     module Helpers
+      # Evaluates any defined hooks with the given name and returns the result.
+      #
+      # Each hook is evaluated and passed any provided arguments, and the result
+      # is concatenated together. If no hooks are defined, and a block is passed
+      # to this helper, then the block will be evaluated instead.
+      #
+      # name  - Name of hook to evaluate
+      # args  - Arguments to pass to hook blocks
+      # block - Optional block to evaluate as a fallback if no hooks are defined
+      #
+      # Examples
+      #
+      #   <%= hook("index.toolbar.primary", toolbar) %>
+      #
+      #   <%= hook("view.title") do %>
+      #     Default Title
+      #   <% end %>
+      #
+      # Returns a HTML-safe string.
       def hook(name, *args, &block)
         hooks = hooks(name)
 
@@ -13,6 +32,8 @@ module Trestle
         end
       end
 
+      # Returns true or false depending on whether there are any defined hooks
+      # (either on the current admin or globally) with the given name.
       def hook?(name)
         hooks(name).any?
       end

--- a/lib/trestle/tab.rb
+++ b/lib/trestle/tab.rb
@@ -6,7 +6,7 @@ module Trestle
 
     attr_reader :name, :options
 
-    def initialize(name, options={})
+    def initialize(name, **options)
       @name, @options = name, options
     end
 

--- a/lib/trestle/table/column.rb
+++ b/lib/trestle/table/column.rb
@@ -61,7 +61,8 @@ module Trestle
           return if options.key?(:header) && options[:header].in?([nil, false])
 
           if @table.sortable? && @column.sortable?
-            @template.sort_link(header_text, @column.sort_field, **@column.sort_options)
+            link_options = @column.sort_options.slice(:default, :default_order)
+            @template.sort_link(header_text, @column.sort_field, **link_options)
           else
             header_text
           end

--- a/lib/trestle/table/column.rb
+++ b/lib/trestle/table/column.rb
@@ -61,7 +61,7 @@ module Trestle
           return if options.key?(:header) && options[:header].in?([nil, false])
 
           if @table.sortable? && @column.sortable?
-            @template.sort_link(header_text, @column.sort_field, @column.sort_options)
+            @template.sort_link(header_text, @column.sort_field, **@column.sort_options)
           else
             header_text
           end

--- a/lib/trestle/table/column.rb
+++ b/lib/trestle/table/column.rb
@@ -70,7 +70,7 @@ module Trestle
 
         def content(instance)
           value = column_value(instance)
-          content = @template.format_value(value, options)
+          content = @template.format_value(value, **options)
 
           if value.respond_to?(:id) && options[:link] != false
             # Column value was a model instance (e.g. from an association).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,4 +51,8 @@ RSpec.configure do |config|
       Object.send(:remove_const, const)
     end
   end
+
+  config.around(:example, :tz) do |example|
+    Time.use_zone(example.metadata[:tz]) { example.run }
+  end
 end

--- a/spec/trestle/helpers/avatar_helper_spec.rb
+++ b/spec/trestle/helpers/avatar_helper_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/avatar_helper'
-
-describe Trestle::AvatarHelper do
-  include Trestle::AvatarHelper
-
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::TextHelper
-  include ActionView::Context
-
+describe Trestle::AvatarHelper, type: :helper do
   describe "#avatar" do
     let(:image) { tag.img(src: "avatar.png") }
 

--- a/spec/trestle/helpers/avatar_helper_spec.rb
+++ b/spec/trestle/helpers/avatar_helper_spec.rb
@@ -10,7 +10,7 @@ describe Trestle::AvatarHelper do
   include ActionView::Context
 
   describe "#avatar" do
-    let(:image) { content_tag(:img, src: "avatar.png") }
+    let(:image) { tag.img(src: "avatar.png") }
 
     it "renders an avatar" do
       result = avatar { image }

--- a/spec/trestle/helpers/card_helper_spec.rb
+++ b/spec/trestle/helpers/card_helper_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/card_helper'
+
+describe Trestle::CardHelper do
+  include Trestle::CardHelper
+
+  include ActionView::Helpers::TagHelper
+
+  describe "#card" do
+    it "returns a .card <div> containing a .card-body" do
+      result = card { "Content" }
+
+      expect(result).to have_tag("div.card") do
+        with_tag "div.card-body", text: "Content"
+      end
+    end
+
+    it "applies any additional attributes to the .card <div> tag (merging classes)" do
+      result = card(id: "mycard", class: "text-bg-primary") { "Content" }
+
+      expect(result).to have_tag("div#mycard.card.text-bg-primary") do
+        with_tag "div.card-body", text: "Content"
+      end
+    end
+
+    it "prepends a header if supplied" do
+      result = card(header: "Header Text")
+
+      expect(result).to have_tag("div.card") do
+        with_tag "div.card-header", text: "Header Text"
+      end
+    end
+
+    it "appends a footer if supplied" do
+      result = card(footer: "Footer Text")
+
+      expect(result).to have_tag("div.card") do
+        with_tag "div.card-footer", text: "Footer Text"
+      end
+    end
+  end
+end

--- a/spec/trestle/helpers/card_helper_spec.rb
+++ b/spec/trestle/helpers/card_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/card_helper'
-
-describe Trestle::CardHelper do
-  include Trestle::CardHelper
-
-  include ActionView::Helpers::TagHelper
-
+describe Trestle::CardHelper, type: :helper do
   describe "#card" do
     it "returns a .card <div> containing a .card-body" do
       result = card { "Content" }

--- a/spec/trestle/helpers/card_helper_spec.rb
+++ b/spec/trestle/helpers/card_helper_spec.rb
@@ -28,7 +28,7 @@ describe Trestle::CardHelper do
       result = card(header: "Header Text")
 
       expect(result).to have_tag("div.card") do
-        with_tag "div.card-header", text: "Header Text"
+        with_tag "header.card-header", text: "Header Text"
       end
     end
 
@@ -36,7 +36,7 @@ describe Trestle::CardHelper do
       result = card(footer: "Footer Text")
 
       expect(result).to have_tag("div.card") do
-        with_tag "div.card-footer", text: "Footer Text"
+        with_tag "footer.card-footer", text: "Footer Text"
       end
     end
   end

--- a/spec/trestle/helpers/container_helper_spec.rb
+++ b/spec/trestle/helpers/container_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/container_helper'
+
+describe Trestle::ContainerHelper do
+  include Trestle::ContainerHelper
+
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
+  include ActionView::Context
+
+  describe "#container" do
+    it "captures the block and renders within .main-content-container > .main-content divs" do
+      result = container { "Main content" }
+
+      expect(result).to have_tag("div.main-content-container") do
+        with_tag "div.main-content", text: "Main content"
+      end
+    end
+
+    it "applies any additional attributes to the .main-content-container <div> tag (merging classes)" do
+      result = container(id: "mycontainer", class: "mycontainer-class")
+      expect(result).to have_tag("div#mycontainer.main-content-container.mycontainer-class")
+    end
+
+    context "with a sidebar" do
+      it "yields a capture block to provide sidebar content" do
+        result = container do |c|
+          c.sidebar { "Sidebar" }
+          "Main content"
+        end
+
+        expect(result).to have_tag("div.main-content-container") do
+          with_tag "div.main-content", text: "Main content"
+          with_tag "aside.main-content-sidebar", text: "Sidebar"
+        end
+      end
+
+      it "applies any additional attributes on the .main-content-sidebar <aside> tag (merging classes)" do
+        result = container do |c|
+          c.sidebar(id: "mysidebar", class: "mysidebar-class") { "Sidebar" }
+          "Main content"
+        end
+
+        expect(result).to have_tag("div.main-content-container") do
+          with_tag "aside#mysidebar.main-content-sidebar.mysidebar-class"
+        end
+      end
+    end
+  end
+end

--- a/spec/trestle/helpers/container_helper_spec.rb
+++ b/spec/trestle/helpers/container_helper_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/container_helper'
-
-describe Trestle::ContainerHelper do
-  include Trestle::ContainerHelper
-
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::TextHelper
-  include ActionView::Context
-
+describe Trestle::ContainerHelper, type: :helper do
   describe "#container" do
     it "captures the block and renders within .main-content-container > .main-content divs" do
       result = container { "Main content" }

--- a/spec/trestle/helpers/form_helper_spec.rb
+++ b/spec/trestle/helpers/form_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/form_helper'
-
-describe Trestle::FormHelper do
-  include Trestle::FormHelper
-
+describe Trestle::FormHelper, type: :helper do
   let(:admin) { double(parameter_name: :article) }
   let(:instance) { double }
 

--- a/spec/trestle/helpers/form_helper_spec.rb
+++ b/spec/trestle/helpers/form_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/form_helper'
+
+describe Trestle::FormHelper do
+  include Trestle::FormHelper
+
+  let(:admin) { double(parameter_name: :article) }
+  let(:instance) { double }
+
+  let(:block) { Proc.new {} }
+  let(:builder) { double }
+  let(:html_tag) { double }
+
+  describe "#trestle_form_for" do
+    it "calls form_for with default options" do
+      expect(self).to receive(:form_for).with(instance, builder: Trestle::Form::Builder, as: :article, data: { controller: "keyboard-submit form-loading form-error" }, &block)
+      trestle_form_for(instance, &block)
+    end
+
+    it "allows appending a custom Stimulus data-controller" do
+      expect(self).to receive(:form_for).with(instance, builder: Trestle::Form::Builder, as: :article, data: { controller: "keyboard-submit form-loading form-error custom-form" })
+      trestle_form_for(instance, data: { controller: "custom-form" })
+    end
+
+    it "sets ActionView::Base.field_error_proc within the block" do
+      allow(self).to receive(:form_for).and_yield(builder)
+
+      trestle_form_for(instance) do
+        expect(::ActionView::Base.field_error_proc.call(html_tag, instance)).to eq(html_tag)
+      end
+    end
+
+    it "allows access to the form builder within the block using the #form helper" do
+      allow(self).to receive(:form_for).and_yield(builder)
+
+      trestle_form_for(instance) do |f|
+        expect(form).to eq(f)
+      end
+    end
+  end
+end

--- a/spec/trestle/helpers/format_helper_spec.rb
+++ b/spec/trestle/helpers/format_helper_spec.rb
@@ -5,55 +5,45 @@ require_relative '../../../app/helpers/trestle/format_helper'
 describe Trestle::FormatHelper do
   include Trestle::FormatHelper
 
-  before(:each) do
-    allow(self).to receive(:truncate) { |v| v }
-  end
+  include Trestle::DisplayHelper
+  include Trestle::IconHelper
+  include Trestle::StatusHelper
+  include Trestle::TimestampHelper
+
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::DateHelper
+  include ActionView::Helpers::NumberHelper
+  include ActionView::Helpers::TextHelper
+  include ActionView::Helpers::TranslationHelper
 
   describe "#format_value" do
     it "automatically formats timestamp values" do
       time = Time.now
-      timestamp = double
-
-      expect(self).to receive(:timestamp).with(time).and_return(timestamp)
-      expect(format_value(time)).to eq(timestamp)
+      expect(format_value(time)).to eq(timestamp(time))
     end
 
     it "automatically formats date values" do
       date = Date.today
-      datestamp = double
-
-      expect(self).to receive(:datestamp).with(date).and_return(datestamp)
-      expect(format_value(date)).to eq(datestamp)
+      expect(format_value(date)).to eq(datestamp(date))
     end
 
     it "returns 'none' text for nil values" do
-      blank = double
-
-      expect(self).to receive(:content_tag).with(:span, "None", class: "blank").and_return(blank)
-      expect(format_value(nil)).to eq(blank)
+      result = format_value(nil)
+      expect(result).to have_tag("span.blank", text: "None")
     end
 
     it "returns custom blank text when :blank String option provided" do
-      blank = double
-
-      expect(self).to receive(:content_tag).with(:span, "Empty", class: "blank").and_return(blank)
-      expect(format_value(nil, blank: "Empty")).to eq(blank)
+      result = format_value(nil, blank: "Empty")
+      expect(result).to have_tag("span.blank", text: "Empty")
     end
 
     it "calls custom blank block when :blank option is callable" do
-      blank = double
-
-      expect(self).to receive(:icon).with("fa fa-ban").and_return(blank)
-      expect(format_value(nil, blank: -> { icon("fa fa-ban") })).to eq(blank)
+      result = format_value(nil, blank: -> { icon("fa fa-ban") })
+      expect(result).to have_tag("i.fa.fa-ban")
     end
 
     it "automatically formats true values" do
-      status = double
-      icon = double
-
-      expect(self).to receive(:icon).with("fa fa-check").and_return(icon)
-      expect(self).to receive(:status_tag).with(icon, :success).and_return(status)
-      expect(format_value(true)).to eq(status)
+      expect(format_value(true)).to eq(status_tag(icon("fa fa-check"), :success))
     end
 
     it "leaves false values empty" do
@@ -61,41 +51,30 @@ describe Trestle::FormatHelper do
     end
 
     it "calls display for model-like values" do
-      representation = double
-      model = double(id: "123")
-
-      expect(self).to receive(:display).with(model).and_return(representation)
-      expect(format_value(model)).to eq(representation)
+      model = double(id: "123", display_name: "Display 123")
+      expect(format_value(model)).to eq("Display 123")
     end
 
     it "automatically formats array values" do
-      list, items = double, double
-      first_item, second_item = double, double
+      result = format_value(["First", "Second"])
 
-      expect(self).to receive(:content_tag).with(:li, "First").and_return(first_item)
-      expect(self).to receive(:content_tag).with(:li, "Second").and_return(second_item)
-      expect(self).to receive(:safe_join).with([first_item, second_item], "\n").and_return(items)
-      expect(self).to receive(:content_tag).with(:ol, items).and_return(list)
-      expect(format_value(["First", "Second"])).to eq(list)
+      expect(result).to have_tag("ol") do
+        with_tag "li", text: "First"
+        with_tag "li", text: "Second"
+      end
     end
 
     it "formats value as currency" do
-      currency = double
-
-      expect(self).to receive(:number_to_currency).with(123.45).and_return(currency)
-      expect(format_value(123.45, format: :currency)).to eq(currency)
+      expect(format_value(123.45, format: :currency)).to eq("$123.45")
     end
 
     it "formats values as tags" do
-      tags = double
-      list = double
-      first_tag, second_tag = double, double
+      result = format_value(["First", "Second"], format: :tags)
 
-      expect(self).to receive(:content_tag).with(:span, "First", class: "tag tag-primary").and_return(first_tag)
-      expect(self).to receive(:content_tag).with(:span, "Second", class: "tag tag-primary").and_return(second_tag)
-      expect(self).to receive(:safe_join).with([first_tag, second_tag]).and_return(tags)
-      expect(self).to receive(:content_tag).with(:div, tags, class: "tag-list").and_return(list)
-      expect(format_value(["First", "Second"], format: :tags)).to eq(list)
+      expect(result).to have_tag("div.tag-list") do
+        with_tag "span.tag.tag-primary", text: "First"
+        with_tag "span.tag.tag-primary", text: "Second"
+      end
     end
   end
 end

--- a/spec/trestle/helpers/format_helper_spec.rb
+++ b/spec/trestle/helpers/format_helper_spec.rb
@@ -17,64 +17,72 @@ describe Trestle::FormatHelper do
   include ActionView::Helpers::TranslationHelper
 
   describe "#format_value" do
-    it "automatically formats timestamp values" do
-      time = Time.now
-      expect(format_value(time)).to eq(timestamp(time))
-    end
+    describe "autoformatting" do
+      it "automatically formats timestamp values" do
+        time = Time.now
+        expect(format_value(time)).to eq(timestamp(time))
+      end
 
-    it "automatically formats date values" do
-      date = Date.today
-      expect(format_value(date)).to eq(datestamp(date))
-    end
+      it "automatically formats date values" do
+        date = Date.today
+        expect(format_value(date)).to eq(datestamp(date))
+      end
 
-    it "returns 'none' text for nil values" do
-      result = format_value(nil)
-      expect(result).to have_tag("span.blank", text: "None")
-    end
+      it "returns 'none' text for nil values" do
+        result = format_value(nil)
+        expect(result).to have_tag("span.blank", text: "None")
+      end
 
-    it "returns custom blank text when :blank String option provided" do
-      result = format_value(nil, blank: "Empty")
-      expect(result).to have_tag("span.blank", text: "Empty")
-    end
+      it "returns custom blank text when :blank String option provided" do
+        result = format_value(nil, blank: "Empty")
+        expect(result).to have_tag("span.blank", text: "Empty")
+      end
 
-    it "calls custom blank block when :blank option is callable" do
-      result = format_value(nil, blank: -> { icon("fa fa-ban") })
-      expect(result).to have_tag("i.fa.fa-ban")
-    end
+      it "calls custom blank block when :blank option is callable" do
+        result = format_value(nil, blank: -> { icon("fa fa-ban") })
+        expect(result).to have_tag("i.fa.fa-ban")
+      end
 
-    it "automatically formats true values" do
-      expect(format_value(true)).to eq(status_tag(icon("fa fa-check"), :success))
-    end
+      it "automatically formats true values" do
+        expect(format_value(true)).to eq(status_tag(icon("fa fa-check"), :success))
+      end
 
-    it "leaves false values empty" do
-      expect(format_value(false)).to be_nil
-    end
+      it "leaves false values empty" do
+        expect(format_value(false)).to be_nil
+      end
 
-    it "calls display for model-like values" do
-      model = double(id: "123", display_name: "Display 123")
-      expect(format_value(model)).to eq("Display 123")
-    end
+      it "calls display for model-like values" do
+        model = double(id: "123", display_name: "Display 123")
+        expect(format_value(model)).to eq("Display 123")
+      end
 
-    it "automatically formats array values" do
-      result = format_value(["First", "Second"])
+      it "automatically formats array values" do
+        result = format_value(["First", "Second"])
 
-      expect(result).to have_tag("ol") do
-        with_tag "li", text: "First"
-        with_tag "li", text: "Second"
+        expect(result).to have_tag("ol") do
+          with_tag "li", text: "First"
+          with_tag "li", text: "Second"
+        end
       end
     end
 
-    it "formats value as currency" do
+    it "formats value as currency with format: :currency" do
       expect(format_value(123.45, format: :currency)).to eq("$123.45")
     end
 
-    it "formats values as tags" do
+    it "formats values as tags with format: :tags" do
       result = format_value(["First", "Second"], format: :tags)
 
       expect(result).to have_tag("div.tag-list") do
         with_tag "span.tag.tag-primary", text: "First"
         with_tag "span.tag.tag-primary", text: "Second"
       end
+    end
+
+    it "raises ArgumentError with an invalid format" do
+      expect {
+        format_value(123, format: :invalid)
+      }.to raise_error(ArgumentError, "unknown format: invalid")
     end
   end
 end

--- a/spec/trestle/helpers/format_helper_spec.rb
+++ b/spec/trestle/helpers/format_helper_spec.rb
@@ -1,20 +1,10 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/format_helper'
-
-describe Trestle::FormatHelper do
-  include Trestle::FormatHelper
-
+describe Trestle::FormatHelper, type: :helper do
   include Trestle::DisplayHelper
   include Trestle::IconHelper
   include Trestle::StatusHelper
   include Trestle::TimestampHelper
-
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::DateHelper
-  include ActionView::Helpers::NumberHelper
-  include ActionView::Helpers::TextHelper
-  include ActionView::Helpers::TranslationHelper
 
   describe "#format_value" do
     describe "autoformatting" do

--- a/spec/trestle/helpers/gravatar_helper_spec.rb
+++ b/spec/trestle/helpers/gravatar_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/gravatar_helper'
-
-describe Trestle::GravatarHelper do
-  include Trestle::GravatarHelper
-
-  include ActionView::Helpers::AssetTagHelper
-
+describe Trestle::GravatarHelper, type: :helper do
   let(:email) { "sam@trestle.io" }
 
   describe "#gravatar_image_tag" do

--- a/spec/trestle/helpers/gravatar_helper_spec.rb
+++ b/spec/trestle/helpers/gravatar_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/gravatar_helper'
+
+describe Trestle::GravatarHelper do
+  include Trestle::GravatarHelper
+
+  include ActionView::Helpers::AssetTagHelper
+
+  let(:email) { "sam@trestle.io" }
+
+  describe "#gravatar_image_tag" do
+    it "returns an image tag using the Gravatar URL for the given email" do
+      expect(gravatar_image_tag(email)).to have_tag("img", with: { src: "https://www.gravatar.com/avatar/b83de56aa24349d584baf052299494f1.png?d=mp" })
+    end
+
+    it "passes options to the gravatar_image_url helper" do
+      expect(gravatar_image_tag(email, size: 100, d: "retro")).to have_tag("img", with: { src: "https://www.gravatar.com/avatar/b83de56aa24349d584baf052299494f1.png?d=retro&size=100" })
+    end
+
+    it "is aliased as #gravatar" do
+      expect(gravatar(email)).to eq(gravatar_image_tag(email))
+    end
+  end
+
+  describe "#gravatar_image_url" do
+    it "returns the Gravatar URL for the given email" do
+      expect(gravatar_image_url(email)).to eq("https://www.gravatar.com/avatar/b83de56aa24349d584baf052299494f1.png?d=mp")
+    end
+
+    it "appends options as query params" do
+      expect(gravatar_image_url(email, size: 100, d: "retro")).to eq("https://www.gravatar.com/avatar/b83de56aa24349d584baf052299494f1.png?d=retro&size=100")
+    end
+  end
+end

--- a/spec/trestle/helpers/grid_helper_spec.rb
+++ b/spec/trestle/helpers/grid_helper_spec.rb
@@ -6,7 +6,6 @@ describe Trestle::GridHelper do
   include Trestle::GridHelper
 
   include ActionView::Helpers::TagHelper
-  include ActionView::Context
 
   describe "#row" do
     it "creates a div with class 'row'" do

--- a/spec/trestle/helpers/grid_helper_spec.rb
+++ b/spec/trestle/helpers/grid_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/grid_helper'
-
-describe Trestle::GridHelper do
-  include Trestle::GridHelper
-
-  include ActionView::Helpers::TagHelper
-
+describe Trestle::GridHelper, type: :helper do
   describe "#row" do
     it "creates a div with class 'row'" do
       expect(row { "content" }).to have_tag(".row", text: "content")

--- a/spec/trestle/helpers/hook_helper_spec.rb
+++ b/spec/trestle/helpers/hook_helper_spec.rb
@@ -7,7 +7,6 @@ describe Trestle::HookHelper do
 
   include ActionView::Helpers::OutputSafetyHelper
   include ActionView::Helpers::CaptureHelper
-  include ActionView::Context
 
   describe "#hook" do
     it "calls and concatenates each hook" do

--- a/spec/trestle/helpers/hook_helper_spec.rb
+++ b/spec/trestle/helpers/hook_helper_spec.rb
@@ -1,13 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/hook_helper'
-
-describe Trestle::HookHelper do
-  include Trestle::HookHelper
-
-  include ActionView::Helpers::OutputSafetyHelper
-  include ActionView::Helpers::CaptureHelper
-
+describe Trestle::HookHelper, type: :helper do
   describe "#hook" do
     it "calls and concatenates each hook" do
       Trestle.config.hook("test-hook") { "abc" }

--- a/spec/trestle/helpers/i18n_helper_spec.rb
+++ b/spec/trestle/helpers/i18n_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/i18n_helper'
-
-describe Trestle::I18nHelper do
-  include Trestle::I18nHelper
-
+describe Trestle::I18nHelper, type: :helper do
   describe "#i18n_fallbacks" do
     it "delegates to I18n.fallbacks if available" do
       allow(I18n).to receive(:fallbacks).and_return({ ca: ["ca", "es-ES", "es"] }.with_indifferent_access)

--- a/spec/trestle/helpers/icon_helper_spec.rb
+++ b/spec/trestle/helpers/icon_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/icon_helper'
-
-describe Trestle::IconHelper do
-  include Trestle::IconHelper
-
-  include ActionView::Helpers::TagHelper
-
+describe Trestle::IconHelper, type: :helper do
   describe "#icon" do
     it "returns an <i> tag with the given classes" do
       result = icon("fas", "fa-star")

--- a/spec/trestle/helpers/icon_helper_spec.rb
+++ b/spec/trestle/helpers/icon_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/icon_helper'
+
+describe Trestle::IconHelper do
+  include Trestle::IconHelper
+
+  include ActionView::Helpers::TagHelper
+
+  describe "#icon" do
+    it "returns an <i> tag with the given classes" do
+      result = icon("fas", "fa-star")
+      expect(result).to have_tag("i.fas.fa-star")
+    end
+
+    it "applies any additional attributes to the <i> tag (merging classes)" do
+      result = icon("fas", "fa-star", class: "fa-fw", id: "icon")
+      expect(result).to have_tag("i#icon.fas.fa-star.fa-fw")
+    end
+  end
+end

--- a/spec/trestle/helpers/modal_helper_spec.rb
+++ b/spec/trestle/helpers/modal_helper_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/modal_helper'
+
+describe Trestle::ModalHelper do
+  include Trestle::ModalHelper
+
+  describe "#modal_options!" do
+    it "merges hash with existing modal options" do
+      modal_options!(class: "modal-class")
+      modal_options!(id: "modal-id", controller: "modal-controller")
+
+      expect(modal_options).to eq({
+        class: "modal-class",
+        id: "modal-id",
+        controller: "modal-controller"
+      })
+    end
+  end
+
+  describe "#modal_wrapper_attributes" do
+    it "returns core HTML attributes for the modal wrapper element" do
+      expect(modal_wrapper_attributes).to eq({
+        class: ["modal", "fade"],
+        tabindex: "-1",
+        role: "dialog",
+        data: { controller: "modal" }
+      })
+    end
+
+    it "merges the wrapper class and id from modal_options if provided" do
+      modal_options!(wrapper_class: "custom-modal", id: "custom-modal-id")
+
+      expect(modal_wrapper_attributes).to eq({
+        class: ["modal", "fade", "custom-modal"],
+        tabindex: "-1",
+        role: "dialog",
+        data: { controller: "modal" },
+        id: "custom-modal-id"
+      })
+    end
+
+    it "merges teh controller from modal_options if provided" do
+      modal_options!(controller: "custom-modal")
+
+      expect(modal_wrapper_attributes).to eq({
+        class: ["modal", "fade"],
+        tabindex: "-1",
+        role: "dialog",
+        data: { controller: "modal custom-modal" }
+      })
+    end
+  end
+
+  describe "#modal_dialog_attributes" do
+    it "returns core HTML attributes for the modal-dialog element" do
+      expect(modal_dialog_attributes).to eq({ class: ["modal-dialog"], role: "document" })
+    end
+
+    it "merges the class from modal_options if provided" do
+      modal_options!(class: "modal-lg")
+      expect(modal_dialog_attributes).to eq({ class: ["modal-dialog", "modal-lg"], role: "document" })
+    end
+  end
+end

--- a/spec/trestle/helpers/modal_helper_spec.rb
+++ b/spec/trestle/helpers/modal_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/modal_helper'
-
-describe Trestle::ModalHelper do
-  include Trestle::ModalHelper
-
+describe Trestle::ModalHelper, type: :helper do
   describe "#modal_options!" do
     it "merges hash with existing modal options" do
       modal_options!(class: "modal-class")

--- a/spec/trestle/helpers/navigation_helper_spec.rb
+++ b/spec/trestle/helpers/navigation_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/navigation_helper'
-
-describe Trestle::NavigationHelper do
-  include Trestle::NavigationHelper
-
+describe Trestle::NavigationHelper, type: :helper do
   describe "#current_admin?" do
     context "when admin is undefined" do
       it "returns false" do

--- a/spec/trestle/helpers/params_helper_spec.rb
+++ b/spec/trestle/helpers/params_helper_spec.rb
@@ -32,25 +32,23 @@ describe Trestle::ParamsHelper do
       end
     end
 
-    if Rails.gem_version > Gem::Version.new("5.1")
-      context "when Trestle.config.persistent_params contains a hash declaration" do
-        before(:each) do
-          expect(Trestle.config).to receive(:persistent_params).and_return([:sort, { hash: {} }, :order])
-        end
+    context "when Trestle.config.persistent_params contains a hash declaration" do
+      before(:each) do
+        expect(Trestle.config).to receive(:persistent_params).and_return([:sort, { hash: {} }, :order])
+      end
 
-        let(:params) do
-          ActionController::Parameters.new({
-            sort: :field,
-            order: "asc",
-            ignore: "me",
-            hash: { key: "value" },
-            ignore_hash: { abc: "123" }
-          })
-        end
+      let(:params) do
+        ActionController::Parameters.new({
+          sort: :field,
+          order: "asc",
+          ignore: "me",
+          hash: { key: "value" },
+          ignore_hash: { abc: "123" }
+        })
+      end
 
-        it "includes persistent hash param" do
-          expect(persistent_params).to eq(ActionController::Parameters.new(sort: :field, order: "asc", hash: { key: "value" }).permit!)
-        end
+      it "includes persistent hash param" do
+        expect(persistent_params).to eq(ActionController::Parameters.new(sort: :field, order: "asc", hash: { key: "value" }).permit!)
       end
     end
   end

--- a/spec/trestle/helpers/params_helper_spec.rb
+++ b/spec/trestle/helpers/params_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/params_helper'
-
-describe Trestle::ParamsHelper do
-  include Trestle::ParamsHelper
-
+describe Trestle::ParamsHelper, type: :helper do
   let(:params) { ActionController::Parameters.new(sort: :field, order: "asc", ignore: "me") }
 
   describe "#persistent_params" do

--- a/spec/trestle/helpers/sort_helper_spec.rb
+++ b/spec/trestle/helpers/sort_helper_spec.rb
@@ -7,7 +7,7 @@ describe Trestle::SortHelper::SortLink do
   let(:params) { {} }
   let(:parameters) { ActionController::Parameters.new(params) }
 
-  subject(:link) { Trestle::SortHelper::SortLink.new(:field, parameters, options)}
+  subject(:link) { Trestle::SortHelper::SortLink.new(:field, parameters, **options)}
 
   describe "#active?" do
     context "when the sort param matches the field name" do

--- a/spec/trestle/helpers/sort_helper_spec.rb
+++ b/spec/trestle/helpers/sort_helper_spec.rb
@@ -1,91 +1,91 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/sort_helper'
+describe Trestle::SortHelper, type: :helper do
+  describe Trestle::SortHelper::SortLink do
+    let(:options) { {} }
+    let(:params) { {} }
+    let(:parameters) { ActionController::Parameters.new(params) }
 
-describe Trestle::SortHelper::SortLink do
-  let(:options) { {} }
-  let(:params) { {} }
-  let(:parameters) { ActionController::Parameters.new(params) }
+    subject(:link) { Trestle::SortHelper::SortLink.new(:field, parameters, **options)}
 
-  subject(:link) { Trestle::SortHelper::SortLink.new(:field, parameters, **options)}
-
-  describe "#active?" do
-    context "when the sort param matches the field name" do
-      let(:params) { { sort: "field" } }
-      it { is_expected.to be_active }
-    end
-
-    context "when the sort param does not match the field name" do
-      it { is_expected.to_not be_active }
-    end
-
-    context "on a default field" do
-      let(:options) { { default: true } }
-
-      context "when no sort param is present" do
-        it { is_expected.to be_active }
-      end
-
+    describe "#active?" do
       context "when the sort param matches the field name" do
         let(:params) { { sort: "field" } }
         it { is_expected.to be_active }
       end
 
       context "when the sort param does not match the field name" do
-        let(:params) { { sort: "other" } }
         it { is_expected.to_not be_active }
       end
-    end
-  end
 
-  describe "#params" do
-    context "when inactive" do
-      it "returns params for ascending order" do
-        expect(link.params).to eq(ActionController::Parameters.new(sort: :field, order: "asc"))
+      context "on a default field" do
+        let(:options) { { default: true } }
+
+        context "when no sort param is present" do
+          it { is_expected.to be_active }
+        end
+
+        context "when the sort param matches the field name" do
+          let(:params) { { sort: "field" } }
+          it { is_expected.to be_active }
+        end
+
+        context "when the sort param does not match the field name" do
+          let(:params) { { sort: "other" } }
+          it { is_expected.to_not be_active }
+        end
       end
     end
 
-    context "when active" do
-      let(:params) { { sort: "field", order: "asc" } }
+    describe "#params" do
+      context "when inactive" do
+        it "returns params for ascending order" do
+          expect(link.params).to eq(ActionController::Parameters.new(sort: :field, order: "asc"))
+        end
+      end
 
-      it "returns params for opposite direction" do
-        expect(link.params).to eq(ActionController::Parameters.new(sort: :field, order: "desc"))
+      context "when active" do
+        let(:params) { { sort: "field", order: "asc" } }
+
+        it "returns params for opposite direction" do
+          expect(link.params).to eq(ActionController::Parameters.new(sort: :field, order: "desc"))
+        end
+      end
+
+      context "with existing params" do
+        let(:params) { { q: "search query" } }
+
+        it "merges in sort params" do
+          expect(link.params).to eq(ActionController::Parameters.new(q: "search query", sort: :field, order: "asc"))
+        end
       end
     end
 
-    context "with existing params" do
-      let(:params) { { q: "search query" } }
-
-      it "merges in sort params" do
-        expect(link.params).to eq(ActionController::Parameters.new(q: "search query", sort: :field, order: "asc"))
-      end
-    end
-  end
-
-  describe "#classes" do
-    context "when inactive" do
-      it "consists of only the sort class" do
-        expect(link.classes).to eq(["sort"])
-      end
-    end
-
-    context "when active" do
-      let(:params) { { sort: "field" } }
-
-      it "includes the active class" do
-        expect(link.classes).to include("active")
+    describe "#classes" do
+      context "when inactive" do
+        it "consists of only the sort class" do
+          expect(link.classes).to eq(["sort"])
+        end
       end
 
-      it "includes the sort-asc class" do
-        expect(link.classes).to include("sort-asc")
+      context "when active" do
+        let(:params) { { sort: "field" } }
+
+        it "includes the active class" do
+          expect(link.classes).to include("active")
+        end
+
+        it "includes the sort-asc class" do
+          expect(link.classes).to include("sort-asc")
+        end
       end
-    end
 
-    context "when active in descending order" do
-      let(:params) { { sort: "field", order: "desc" } }
+      context "when active in descending order" do
+        let(:params) { { sort: "field", order: "desc" } }
 
-      it "includes the sort-desc class" do
-        expect(link.classes).to include("sort-desc")
+        it "includes the sort-desc class" do
+          expect(link.classes).to include("sort-desc")
+        end
       end
     end
   end

--- a/spec/trestle/helpers/status_helper_spec.rb
+++ b/spec/trestle/helpers/status_helper_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/status_helper'
+
+describe Trestle::StatusHelper do
+  include Trestle::StatusHelper
+
+  include ActionView::Helpers::TagHelper
+
+  describe "#status_tag" do
+    it "returns a badge with the given label" do
+      result = status_tag("Status")
+      expect(result).to have_tag("span.badge.badge-primary", text: "Status")
+    end
+
+    it "sets the badge class based on the status if provided" do
+      result = status_tag("Warning", :warning)
+      expect(result).to have_tag("span.badge.badge-warning", text: "Warning")
+    end
+
+    it "applies any additional attributes to the badge (merging classes)" do
+      result = status_tag("Status", :info, class: "badge-pill", id: "status")
+      expect(result).to have_tag("span#status.badge.badge-info.badge-pill", text: "Status")
+    end
+
+    it "applies additional attributes if an explicit status is not provided" do
+      result = status_tag("Status", class: "badge-pill", id: "status")
+      expect(result).to have_tag("span#status.badge.badge-primary.badge-pill", text: "Status")
+    end
+  end
+end

--- a/spec/trestle/helpers/status_helper_spec.rb
+++ b/spec/trestle/helpers/status_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/status_helper'
-
-describe Trestle::StatusHelper do
-  include Trestle::StatusHelper
-
-  include ActionView::Helpers::TagHelper
-
+describe Trestle::StatusHelper, type: :helper do
   describe "#status_tag" do
     it "returns a badge with the given label" do
       result = status_tag("Status")

--- a/spec/trestle/helpers/table_helper_spec.rb
+++ b/spec/trestle/helpers/table_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/table_helper'
-
-describe Trestle::TableHelper do
-  include Trestle::TableHelper
-
+describe Trestle::TableHelper, type: :helper do
   let(:admin) { double }
   let(:collection) { double }
   let(:table_object) { Trestle::Table.new }

--- a/spec/trestle/helpers/table_helper_spec.rb
+++ b/spec/trestle/helpers/table_helper_spec.rb
@@ -7,44 +7,51 @@ describe Trestle::TableHelper do
 
   let(:admin) { double }
   let(:collection) { double }
-  let(:table_object) { double }
+  let(:table_object) { Trestle::Table.new }
 
-  context "with a block" do
-    let(:block) { Proc.new {} }
+  describe "#table" do
+    context "with a block" do
+      let(:block) { Proc.new {} }
 
-    it "builds and renders a custom table" do
-      expect(Trestle::Table::Builder).to receive(:build).with({ admin: admin, collection: collection }, &block).and_return(table_object)
-      expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
+      it "builds and renders a custom table" do
+        expect(Trestle::Table::Builder).to receive(:build).with({ admin: admin }, &block).and_return(table_object)
+        expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
 
-      table(admin: admin, collection: collection, &block)
+        table(admin: admin, collection: collection, &block)
+      end
+
+      it "builds and renders using a positional collection argument" do
+        expect(Trestle::Table::Builder).to receive(:build).with({ admin: admin }, &block).and_return(table_object)
+        expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
+
+        table(collection, admin: admin, &block)
+      end
     end
-  end
 
-  context "with a table name" do
-    it "retrieves and renders the named table" do
-      expect(admin).to receive(:tables).and_return({ index: table_object })
-      expect(table_object).to receive(:with_options).with({ sortable: false, collection: collection }).and_return(table_object)
-      expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
+    context "with a table name" do
+      it "retrieves and renders the named table" do
+        expect(admin).to receive(:tables).and_return({ index: table_object })
+        expect(table_object).to receive(:with_options).with({ sortable: false }).and_return(table_object)
+        expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
 
-      table(:index, collection: collection)
+        table(:index, collection: collection)
+      end
+
+      it "raises an ArgumentError if the named table cannot be found" do
+        expect(admin).to receive(:tables).and_return({})
+
+        expect {
+          table(:missing, collection: collection)
+        }.to raise_error(ArgumentError, "Unable to find table named :missing")
+      end
     end
 
-    it "raises an ArgumentError if the named table cannot be found" do
-      expect(admin).to receive(:tables).and_return({})
-
-      expect {
-        table(:missing, collection: collection)
-      }.to raise_error(ArgumentError, "Unable to find table named :missing")
-    end
-  end
-
-  context "with a Trestle::Table instance" do
-    let(:table_object) { Trestle::Table.new }
-
-    it "renders the given table" do
-      expect(table_object).to receive(:with_options).with({ sortable: false, collection: collection }).and_return(table_object)
-      expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
-      table(table_object, collection: collection)
+    context "with a Trestle::Table instance" do
+      it "renders the given table" do
+        expect(table_object).to receive(:with_options).with({ sortable: false }).and_return(table_object)
+        expect(self).to receive(:render).with("trestle/table/table", table: table_object, collection: collection)
+        table(table_object, collection: collection)
+      end
     end
   end
 end

--- a/spec/trestle/helpers/timestamp_helper_spec.rb
+++ b/spec/trestle/helpers/timestamp_helper_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+require_relative '../../../app/helpers/trestle/card_helper'
+
+describe Trestle::TimestampHelper do
+  include Trestle::TimestampHelper
+
+  include ActionView::Helpers::DateHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TranslationHelper
+
+  describe "#timestamp" do
+    let(:time) { Time.zone.local(2024, 8, 21, 12, 34, 56) }
+
+    it "returns nil if time given is nil" do
+      expect(timestamp(nil)).to be_nil
+    end
+
+    it "returns a <time> tag with the given time", tz: "Australia/Perth" do
+      result = timestamp(time)
+
+      expect(result).to have_tag("time.timestamp", with: { datetime: "2024-08-21T12:34:56+08:00" }) do
+        with_tag "span", text: "21st Aug 2024"
+        with_tag "small", text: "12:34 PM"
+      end
+    end
+
+    it "applies any additional attributes to the <time> tag (merging classes)" do
+      result = timestamp(time, id: "special-time", class: "timestamp-inline")
+      expect(result).to have_tag("time#special-time.timestamp.timestamp-inline")
+    end
+
+    it "renders the time with seconds if precision: :seconds is passed" do
+      result = timestamp(time, precision: :seconds)
+
+      expect(result).to have_tag("time.timestamp") do
+        with_tag "small", text: "12:34:56 PM"
+      end
+    end
+
+    it "accepts custom date and time formats" do
+      result = timestamp(time, date_format: "%B %d, %Y", time_format: "%H:%M")
+
+      expect(result).to have_tag("time.timestamp") do
+        with_tag "span", text: "August 21, 2024"
+        with_tag "small", text: "12:34"
+      end
+    end
+  end
+
+  describe "#datestamp" do
+    let(:date) { Date.new(2024, 8, 21) }
+
+    it "returns nil if date given is nil" do
+      expect(datestamp(nil)).to be_nil
+    end
+
+    it "returns a <time> tag with the given date" do
+      result = datestamp(date)
+      expect(result).to have_tag("time.datestamp", text: "8/21/2024", with: { datetime: "2024-08-21" })
+    end
+
+    it "applies any additional attributes to the <time> tag (merging classes)" do
+      result = datestamp(date, id: "special-date", class: "custom-datestamp")
+      expect(result).to have_tag("time#special-date.datestamp.custom-datestamp")
+    end
+
+    it "accepts a custom l10n format" do
+      result = datestamp(date, format: :long)
+      expect(result).to have_tag("time.datestamp", text: "August 21, 2024")
+    end
+  end
+end

--- a/spec/trestle/helpers/timestamp_helper_spec.rb
+++ b/spec/trestle/helpers/timestamp_helper_spec.rb
@@ -1,14 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/card_helper'
-
-describe Trestle::TimestampHelper do
-  include Trestle::TimestampHelper
-
-  include ActionView::Helpers::DateHelper
-  include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::TranslationHelper
-
+describe Trestle::TimestampHelper, type: :helper do
   describe "#timestamp" do
     let(:time) { Time.zone.local(2024, 8, 21, 12, 34, 56) }
 

--- a/spec/trestle/helpers/title_helper_spec.rb
+++ b/spec/trestle/helpers/title_helper_spec.rb
@@ -1,15 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/title_helper'
-
-describe Trestle::TitleHelper do
-  include Trestle::TitleHelper
-
-  include ActionView::Helpers::CaptureHelper
-  include ActionView::Context
-
-  before(:each) { _prepare_context }
-
+describe Trestle::TitleHelper, type: :helper do
   let(:action_name) { "default" }
 
   describe "#title" do

--- a/spec/trestle/helpers/url_helper_spec.rb
+++ b/spec/trestle/helpers/url_helper_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
-require_relative '../../../app/helpers/trestle/url_helper'
-
-describe Trestle::UrlHelper do
-  include Trestle::UrlHelper
-
+describe Trestle::UrlHelper, type: :helper do
   let(:form) { double(modal?: false) }
   let(:admin) { double(form: form) }
   let(:modal_request?) { false }


### PR DESCRIPTION
This PR encompasses an overhaul of the Trestle helpers, particularly in regards to documentation. Comments have been added to most helpers intended for public use.

In addition it:

* Added some missing specs for helper methods
* Improved usage of kwargs options where appropriate
* Updated to `tag.foo` format over legacy `content_tag`
* Some minor cleanup and reorganization of helper modules
  * Removed `turbo_stream_update_flash` helper (use `turbo_stream.flash` instead)
  * Removed separate `format_value_from_options` method
  * Extracted Gravatar helpers into separate module