### PR TITLE
Defer registration of admin models until lookup time

### DIFF
--- a/lib/trestle.rb
+++ b/lib/trestle.rb
@@ -44,8 +44,8 @@ module Trestle
   end
 
   # Builds and registers a new admin resource
-  def self.resource(name, register_model: true, **options, &block)
-    register(Resource::Builder.create(name, options, &block), register_model: register_model)
+  def self.resource(name, **options, &block)
+    register(Resource::Builder.create(name, options, &block))
   end
 
   # Configuration methods

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -104,6 +104,10 @@ module Trestle
         options[:singular]
       end
 
+      def register_model?
+        options[:register_model] != false && !singular?
+      end
+
       def translate(key, options={})
         super(key, options.merge({
           model_name:            model_name.titleize,

--- a/spec/trestle/registry_spec.rb
+++ b/spec/trestle/registry_spec.rb
@@ -37,15 +37,9 @@ describe Trestle::Registry, remove_const: true do
       end
 
       context "with register_model: false" do
-        it "does not register the admin for model lookup" do
-          registry.register(admin, register_model: false)
-          expect(registry.lookup_model(model)).to be_nil
-        end
-      end
+        let(:admin) { Trestle.resource(:test, model: model, register_model: false) }
 
-      context "with a singular admin" do
         it "does not register the admin for model lookup" do
-          allow(admin).to receive(:singular?).and_return(true)
           registry.register(admin)
           expect(registry.lookup_model(model)).to be_nil
         end

--- a/spec/trestle/resource_spec.rb
+++ b/spec/trestle/resource_spec.rb
@@ -26,7 +26,7 @@ describe Trestle::Resource, remove_const: true do
     subject!(:admin) { nil }
 
     it "raises a NameError exception" do
-      expect { definition }.to raise_exception(NameError, "Unable to find model Test. Specify a different model using Trestle.resource(:tests, model: MyModel)")
+      expect { definition.model }.to raise_exception(NameError, "Unable to find model Test. Specify a different model using Trestle.resource(:tests, model: MyModel)")
     end
   end
 
@@ -46,6 +46,18 @@ describe Trestle::Resource, remove_const: true do
 
   it "has a singular parameter name" do
     expect(admin.parameter_name).to eq("test")
+  end
+
+  it "registers the model by default" do
+    expect(admin.register_model?).to be true
+  end
+
+  context "when register_model: false is passed via options" do
+    let(:options) { { register_model: false } }
+
+    it "does not register the model" do
+      expect(admin.register_model?).to be false
+    end
   end
 
   it "has a breadcrumb trail" do
@@ -171,6 +183,10 @@ describe Trestle::Resource, remove_const: true do
 
     it "is singular" do
       expect(admin).to be_singular
+    end
+
+    it "does not register the model" do
+      expect(admin.register_model?).to be false
     end
 
     it "returns the show action path as the default path" do

--- a/spec/trestle/trestle_spec.rb
+++ b/spec/trestle/trestle_spec.rb
@@ -60,14 +60,8 @@ describe Trestle, remove_const: true do
 
     it "registers the admin in the registry" do
       expect(Trestle::Resource::Builder).to receive(:create).with(:test, { path: "/custom" })
-      expect(Trestle.registry).to receive(:register).with(admin, register_model: true)
+      expect(Trestle.registry).to receive(:register).with(admin)
       Trestle.resource(:test, path: "/custom")
-    end
-
-    it "passes the :register_model option to Registry#register" do
-      expect(Trestle::Resource::Builder).to receive(:create).with(:test, { path: "/custom" })
-      expect(Trestle.registry).to receive(:register).with(admin, register_model: false)
-      Trestle.resource(:test, path: "/custom", register_model: false)
     end
   end
 


### PR DESCRIPTION
In order to generate the admin routes, the Trestle reloader must read each admin file when routes are loaded (which is at startup in most cases). However we can defer the lookup and constantization of the admin resource's model until the `Trestle::Registry#lookup_model` method is called. This fixes issues such as #482 where an error in loading a model can mask the root cause of the exception.

Unfortunately an error in an admin definition will still cause a failure at startup time. I don't know at this point whether that is resolvable (in a way that is desirable, i.e. don't just rescue any exceptions).

This PR also pushes the logic of whether an admin resource should register itself for model lookup out of the `Trestle::Registry` class and down to the `Trestle::Resource` itself where it is a better fit.