### PR TITLE
Fix Admin#path when nil passed as action parameter

### DIFF
--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -118,8 +118,14 @@ module Trestle
         "#{name.underscore}/admin"
       end
 
-      def path(action=root_action, options={})
-        Engine.routes.url_for(options.merge(controller: controller_namespace, action: action, only_path: true))
+      def path(action=nil, options={})
+        defaults = {
+          controller: controller_namespace,
+          action: action || root_action,
+          only_path: true
+        }
+
+        Engine.routes.url_for(defaults.merge(options))
       end
 
       def to_param(*)

--- a/spec/dummy/app/admin/singular_post_admin.rb
+++ b/spec/dummy/app/admin/singular_post_admin.rb
@@ -1,4 +1,8 @@
 Trestle.resource(:singular_post, model: Post, singular: true) do
+  menu do
+    item :singular, icon: "fas fa-star"
+  end
+
   remove_action :new, :create, :edit, :destroy
 
   instance do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,8 +36,6 @@ RSpec.configure do |config|
   config.include RSpecHtmlMatchers
 
   config.before(:example) do
-    Trestle.registry.reset!
-
     Trestle.config.hooks = Trestle::Hook::Set.new
     Trestle.config.menus = []
   end


### PR DESCRIPTION
Further fixes to default admin paths for navigation items, following on from #484.