### PR TITLE
Rewrite URL helpers and support :method option on admin_link_to

### DIFF
--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -19,6 +19,7 @@ module Trestle
     #            otherwise falling back to the current admin if available
     # action   - Optional admin action to link to. Will default to :show if instance is provided,
     #            otherwise the admin's root action (usually :index) will be used
+    # method   - Optional request method (e.g. :delete), that will be set as `data-turbo-method`
     # params   - Hash of URL parameters to pass to `instance_path` or `path` admin methods (default: {})
     # options  - Hash of options to forward to the `link_to` helper (default: {})
     # block    - Optional block to capture to use as the link content
@@ -33,7 +34,7 @@ module Trestle
     #
     # Returns a HTML-safe String.
     # Raises ActionController::UrlGenerationError if the admin cannot be automatically inferred.
-    def admin_link_to(content=nil, instance=nil, admin: nil, action: nil, params: {}, **options, &block)
+    def admin_link_to(content=nil, instance=nil, admin: nil, action: nil, method: nil, params: {}, **options, &block)
       # Block given - ignore content parameter and capture content from block
       if block_given?
         instance, content = content, capture(&block)
@@ -65,6 +66,8 @@ module Trestle
       else
         options[:data][:turbo_frame] ||= (modal_request? ? "modal" : "_top")
       end
+
+      options[:data][:turbo_method] ||= method if method
 
       link_to(content, path, options)
     end

--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -106,12 +106,12 @@ module Trestle
 
       if instance
         if target.respond_to?(:instance_path)
-          target.instance_path(instance, **params.merge(action: action))
+          target.instance_path(instance, action: action, **params)
         else
-          target.path(action, **params.merge(id: target.to_param(instance)))
+          target.path(action, params.merge(id: target.to_param(instance)))
         end
       else
-        target.path(action, **params)
+        target.path(action, params)
       end
     end
 

--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -12,15 +12,16 @@ module Trestle
     # 3) It sets data-turbo-frame appropriately for modal and non-modal contexts to ensure
     #    the admin can correctly detect modal requests.
     #
-    # content         - HTML or text content to use as the link content
-    #                   (will be ignored if a block is provided)
-    # instance_or_url - model instance, or explicit String path
-    # options         - Hash of options (default: {})
-    #                   :admin  - Optional explicit admin (symbol or admin class)
-    #                   :action - Controller action to generate the link to
-    #                   :params - Additional params to use when generating the link URL
-    #                   (all other options are forwarded to the `link_to` helper)
-    # block           - Optional block to capture to use as the link content
+    # content  - HTML or text content to use as the link content
+    #            (will be ignored if a block is provided)
+    # instance - Optional model instance, or explicit String path
+    # admin    - Optional admin instance to link to. Will be inferred from instance if provided,
+    #            otherwise falling back to the current admin if available
+    # action   - Optional admin action to link to. Will default to :show if instance is provided,
+    #            otherwise the admin's root action (usually :index) will be used
+    # params   - Hash of URL parameters to pass to `instance_path` or `path` admin methods (default: {})
+    # options  - Hash of options to forward to the `link_to` helper (default: {})
+    # block    - Optional block to capture to use as the link content
     #
     # Examples
     #
@@ -32,62 +33,40 @@ module Trestle
     #
     # Returns a HTML-safe String.
     # Raises ActionController::UrlGenerationError if the admin cannot be automatically inferred.
-    def admin_link_to(content, instance_or_url=nil, options={}, &block)
+    def admin_link_to(content=nil, instance=nil, admin: nil, action: nil, params: {}, **options, &block)
       # Block given - ignore content parameter and capture content from block
       if block_given?
-        instance_or_url, options = content, instance_or_url || {}
-        content = capture(&block)
+        instance, content = content, capture(&block)
       end
 
-      if instance_or_url.is_a?(String)
-        # Treat string URL as regular link
-        link_to(content, instance_or_url, options)
+      # Treat string URL as regular link
+      if instance.is_a?(String)
+        return link_to(content, instance, options)
+      end
+
+      # Determine target admin
+      target = lookup_admin_from_options(
+        instance: instance,
+        admin: admin,
+        fallback: self&.admin,
+        raise: true
+      )
+
+      # Set default action depending on instance or not
+      action ||= (instance ? :show : target.root_action)
+
+      path = admin_url_for(instance, admin: target, action: action, **params)
+
+      # Determine link data options
+      options[:data] ||= {}
+
+      if MODAL_ACTIONS.include?(action) && target&.form&.modal?
+        options[:data][:controller] ||= "modal-trigger"
       else
-        # Normalize options if instance is not provided
-        if instance_or_url.is_a?(Hash)
-          instance, options = nil, instance_or_url
-        else
-          instance = instance_or_url
-        end
-
-        # Determine admin
-        if options.key?(:admin)
-          admin = Trestle.lookup(options.delete(:admin))
-        elsif instance
-          admin = admin_for(instance)
-        end
-
-        admin ||= self.admin if respond_to?(:admin)
-
-        if admin
-          # Ensure admin has controller context
-          admin = admin.new(self) if admin.is_a?(Class)
-
-          # Generate path
-          action = options.delete(:action) || :show
-          params = options.delete(:params) || {}
-
-          if admin.respond_to?(:instance_path) && instance
-            path = admin.instance_path(instance, params.reverse_merge(action: action))
-          else
-            params[:id] ||= admin.to_param(instance) if instance
-            path = admin.path(action, params)
-          end
-
-          # Determine link data options
-          options[:data] ||= {}
-
-          if MODAL_ACTIONS.include?(action) && admin.respond_to?(:form) && admin.form.modal?
-            options[:data][:controller] ||= "modal-trigger"
-          else
-            options[:data][:turbo_frame] ||= (modal_request? ? "modal" : "_top")
-          end
-
-          link_to(content, path, options)
-        else
-          raise ActionController::UrlGenerationError, "An admin could not be inferred. Please specify an admin using the :admin option."
-        end
+        options[:data][:turbo_frame] ||= (modal_request? ? "modal" : "_top")
       end
+
+      link_to(content, path, options)
     end
 
     # Returns the admin path for a given instance.
@@ -97,7 +76,12 @@ module Trestle
     #
     # instance - The model instance to generate a path for
     # admin    - Optional admin (symbol or admin class)
-    # options  - Hash of options to pass to `instance_path` or `path` admin methods
+    # action   - Optional admin action to generate the URL for. Will default to :show if
+    #            instance is provided, otherwise the admin's root action (usually :index)
+    #            will be used
+    # raise    - Whether to raise a ActionController::UrlGenerationError if the admin
+    #            cannot be determined, either from the admin parameter or automatically
+    # params   - Hash of URL parameters to pass to `instance_path` or `path` admin methods
     #
     # Examples
     #
@@ -105,18 +89,26 @@ module Trestle
     #   <%= admin_url_for(article, admin: :special_articles) %>
     #
     # Returns a String, or nil if the admin cannot be automatically inferred.
-    def admin_url_for(instance, admin: nil, **options)
-      admin = Trestle.lookup(admin) if admin
-      admin ||= admin_for(instance)
-      return unless admin
+    def admin_url_for(instance=nil, admin: nil, action: nil, raise: false, **params)
+      target = lookup_admin_from_options(
+        instance: instance,
+        admin: admin,
+        fallback: self&.admin,
+        raise: raise
+      )
+      return unless target
 
-      # Ensure admin has controller context
-      admin = admin.new(self) if admin.is_a?(Class)
+      # Set default action depending on instance or not
+      action ||= (instance ? :show : target.root_action)
 
-      if admin.respond_to?(:instance_path)
-        admin.instance_path(instance, options)
+      if instance
+        if target.respond_to?(:instance_path)
+          target.instance_path(instance, **params.merge(action: action))
+        else
+          target.path(action, **params.merge(id: target.to_param(instance)))
+        end
       else
-        admin.path(options[:action] || :show, id: admin.to_param(instance))
+        target.path(action, **params)
       end
     end
 
@@ -131,6 +123,27 @@ module Trestle
     # Returns a Trestle::Admin subclass or nil if no matching admin found.
     def admin_for(instance)
       Trestle.lookup_model(instance.class)
+    end
+
+  private
+    def lookup_admin_from_options(instance: nil, admin: nil, fallback: nil, raise: true)
+      if admin
+        result = Trestle.lookup(admin)
+      elsif instance
+        result = Trestle.lookup_model(instance.class) || fallback
+      else
+        result = fallback
+      end
+
+      if result
+        # Instantiate admin with current context
+        result = result.new(self) if result.is_a?(Class)
+
+        result
+      elsif raise
+        raise ActionController::UrlGenerationError,
+          "An admin could not be inferred. Please specify an admin using the :admin option."
+      end
     end
   end
 end

--- a/app/helpers/trestle/url_helper.rb
+++ b/app/helpers/trestle/url_helper.rb
@@ -138,10 +138,10 @@ module Trestle
         result = fallback
       end
 
-      if result
+      if result && result.is_a?(Class)
         # Instantiate admin with current context
-        result = result.new(self) if result.is_a?(Class)
-
+        result.new(self)
+      elsif result
         result
       elsif raise
         raise ActionController::UrlGenerationError,

--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -14,6 +14,7 @@ module Trestle
         super
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def respond_to_missing?(name, include_private=false)
       self.class.respond_to?(name, include_private) || super

--- a/lib/trestle/registry.rb
+++ b/lib/trestle/registry.rb
@@ -30,6 +30,9 @@ module Trestle
       # Given object is already an admin class
       return admin if admin.is_a?(Class) && admin < Trestle::Admin
 
+      # Given object is already an admin instance
+      return admin if admin.is_a?(Trestle::Admin)
+
       @admins[admin.to_s]
     end
     alias lookup lookup_admin

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -117,11 +117,9 @@ module Trestle
       end
       alias t translate
 
-      def instance_path(instance, options={})
-        action = options.fetch(:action) { :show }
-        options = options.merge(id: to_param(instance)) unless singular?
-
-        path(action, options)
+      def instance_path(instance, action: :show, **options)
+        options.merge!(id: to_param(instance)) unless singular?
+        path(action, **options)
       end
 
       def routes

--- a/lib/trestle/resource.rb
+++ b/lib/trestle/resource.rb
@@ -119,7 +119,7 @@ module Trestle
 
       def instance_path(instance, action: :show, **options)
         options.merge!(id: to_param(instance)) unless singular?
-        path(action, **options)
+        path(action, options)
       end
 
       def routes

--- a/lib/trestle/resource/toolbar.rb
+++ b/lib/trestle/resource/toolbar.rb
@@ -9,26 +9,26 @@ module Trestle
           return unless action?(:new)
 
           defaults = { action: :new, style: :light, icon: "fa fa-plus", class: "btn-new-resource" }
-          link(label, defaults.merge(attrs))
+          link(label, **defaults.merge(attrs))
         end
 
         def save(label: t("buttons.save", default: "Save %{model_name}"), **attrs)
           defaults = { style: :success }
-          button(label, defaults.merge(attrs))
+          button(label, **defaults.merge(attrs))
         end
 
         def delete(label: t("buttons.delete", default: "Delete %{model_name}"), **attrs)
           return unless action?(:destroy)
 
           defaults = Trestle::Options.new(action: :destroy, style: :danger, icon: "fa fa-trash", data: { turbo_method: "delete", turbo_frame: "_top", controller: "confirm-delete", confirm_delete_placement_value: "bottom" })
-          link(label, instance, defaults.merge(attrs))
+          link(label, instance, **defaults.merge(attrs))
         end
 
         def dismiss(label: t("buttons.ok", default: "OK"), **attrs)
           return unless @template.modal_request?
 
           defaults = Trestle::Options.new(type: :button, style: :light, data: { bs_dismiss: "modal" })
-          button(label, defaults.merge(attrs))
+          button(label, **defaults.merge(attrs))
         end
         alias ok dismiss
 

--- a/lib/trestle/toolbar/builder.rb
+++ b/lib/trestle/toolbar/builder.rb
@@ -5,16 +5,16 @@ module Trestle
         @template = template
       end
 
-      def button(label, options={}, &block)
-        Button.new(@template, label, options, &block)
+      def button(label, **options, &block)
+        Button.new(@template, label, **options, &block)
       end
 
-      def link(label, instance_or_url={}, options={}, &block)
-        Link.new(@template, label, instance_or_url, options, &block)
+      def link(label, instance_or_url=nil, **options, &block)
+        Link.new(@template, label, instance_or_url, **options, &block)
       end
 
-      def dropdown(label=nil, options={}, &block)
-        Dropdown.new(@template, label, options, &block)
+      def dropdown(label=nil, **options, &block)
+        Dropdown.new(@template, label, **options, &block)
       end
 
       # Only methods explicitly tagged as builder methods will be automatically

--- a/lib/trestle/toolbar/item.rb
+++ b/lib/trestle/toolbar/item.rb
@@ -5,15 +5,14 @@ module Trestle
 
       delegate :admin_link_to, :button_tag, :tag, :safe_join, :icon, to: :@template
 
-      def initialize(template, label, options={}, &block)
+      def initialize(template, label, icon: nil, style: nil, **options, &block)
         @template = template
         @label, @options, @block = label, options
 
         @menu = Menu.new(template)
         @menu.build(&block) if block_given?
 
-        @icon = options.delete(:icon)
-        @style = options.delete(:style)
+        @icon, @style = icon, style
       end
 
       def ==(other)
@@ -77,21 +76,13 @@ module Trestle
     class Link < Item
       attr_reader :instance_or_url
 
-      def initialize(template, label, instance_or_url={}, options={}, &block)
-        if instance_or_url.is_a?(Hash)
-          super(template, label, instance_or_url, &block)
-        else
-          super(template, label, options, &block)
-          @instance_or_url = instance_or_url
-        end
+      def initialize(template, label, instance_or_url=nil, **options, &block)
+        super(template, label, **options, &block)
+        @instance_or_url = instance_or_url
       end
 
       def render
-        if @instance_or_url
-          admin_link_to(button_label(label, options), instance_or_url, options)
-        else
-          admin_link_to(button_label(label, options), options)
-        end
+        admin_link_to(button_label(label, options), instance_or_url, **options)
       end
     end
 

--- a/lib/trestle/toolbar/menu.rb
+++ b/lib/trestle/toolbar/menu.rb
@@ -42,7 +42,7 @@ module Trestle
           options[:class] = Array(options[:class])
           options[:class] << "dropdown-item"
 
-          item { admin_link_to(content, instance_or_url, options, &block) }
+          item { admin_link_to(content, instance_or_url, **options, &block) }
         end
 
         def header(text)

--- a/spec/trestle/helpers/url_helper_spec.rb
+++ b/spec/trestle/helpers/url_helper_spec.rb
@@ -141,6 +141,11 @@ describe Trestle::UrlHelper, type: :helper do
         expect(link).to have_tag("a", text: "Admin Link", with: { href: "/admin/test", "data-turbo-frame": "modal" })
       end
     end
+
+    it "sets the data-turbo-method attribute when passed :method option" do
+      link = admin_link_to("Admin Link", admin: :test, method: :post)
+      expect(link).to have_tag("a", text: "Admin Link", with: { href: "/admin/test", "data-turbo-method": "post" })
+    end
   end
 
   describe "#admin_url_for", remove_const: true do

--- a/spec/trestle/helpers/url_helper_spec.rb
+++ b/spec/trestle/helpers/url_helper_spec.rb
@@ -78,7 +78,7 @@ describe Trestle::UrlHelper, type: :helper do
 
     context "when no instance is provided" do
       it "generates a link to the index action of the given admin" do
-        expect(current_admin).to receive(:path).with(:index).and_return("/admin/test")
+        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin/test")
         link = admin_link_to("Collection Link", admin: :test)
         expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
       end
@@ -103,7 +103,7 @@ describe Trestle::UrlHelper, type: :helper do
       end
 
       it "falls back to the current admin if not explicitly provided" do
-        expect(current_admin).to receive(:path).with(:index).and_return("/admin/test")
+        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin/test")
         link = admin_link_to("Collection Link")
         expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
       end
@@ -185,12 +185,12 @@ describe Trestle::UrlHelper, type: :helper do
 
     context "when no instance is given" do
       it "returns the path using by delegating to #path on the admin" do
-        expect(current_admin).to receive(:path).with(:index).and_return("/admin")
+        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin")
         expect(admin_url_for(action: :index)).to eq("/admin")
       end
 
       it "returns the path to the index action by default" do
-        expect(current_admin).to receive(:path).with(:index).and_return("/admin")
+        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin")
         expect(admin_url_for).to eq("/admin")
       end
 
@@ -200,12 +200,12 @@ describe Trestle::UrlHelper, type: :helper do
       end
 
       it "uses the specified admin when passed as a symbol" do
-        expect(alternate_admin).to receive(:path).with(:index).and_return("/alternate")
+        expect(alternate_admin).to receive(:path).with(:index, **{}).and_return("/alternate")
         expect(admin_url_for(action: :index, admin: :alternate)).to eq("/alternate")
       end
 
       it "uses the specified admin when passed as a class" do
-        expect(alternate_admin).to receive(:path).with(:index).and_return("/alternate")
+        expect(alternate_admin).to receive(:path).with(:index, **{}).and_return("/alternate")
         expect(admin_url_for(action: :index, admin: alternate_admin)).to eq("/alternate")
       end
     end

--- a/spec/trestle/helpers/url_helper_spec.rb
+++ b/spec/trestle/helpers/url_helper_spec.rb
@@ -1,132 +1,237 @@
 require 'spec_helper'
 
 describe Trestle::UrlHelper, type: :helper do
-  let(:form) { double(modal?: false) }
-  let(:admin) { double(form: form) }
-  let(:modal_request?) { false }
-
   before(:each) do
-    allow(Trestle).to receive(:lookup).and_return(nil)
-    allow(Trestle).to receive(:lookup).with(admin).and_return(admin)
+    Trestle.registry.reset!
   end
 
-  describe "#admin_link_to" do
-    let(:url) { double }
-    let(:link) { double }
+  describe "#admin_link_to", remove_const: true do
+    let!(:admin) { Trestle.resource(:test, model: model) }
+
+    let(:model) { stub_const("Model", Class.new) }
+    let(:current_admin) { admin.new(self) }
+
+    let(:modal_request?) { false }
+
+    before(:each) do
+      allow(admin).to receive(:new).with(self).and_return(current_admin)
+
+      allow(current_admin).to receive(:path).and_return("/admin/test")
+      allow(current_admin).to receive(:instance_path).and_return("/admin/123")
+    end
 
     context "when a string URL is provided" do
-      let(:url) { "/test" }
-
       it "renders a link to the given URL" do
-        expect(self).to receive(:link_to).with("link content", url, {}).and_return(link)
-        expect(admin_link_to("link content", url)).to eq(link)
+        link = admin_link_to("Link Text", "/url")
+        expect(link).to have_tag("a", text: "Link Text", with: { href: "/url" })
+      end
+
+      it "passes additional options to the link" do
+        link = admin_link_to("Link Text", "/url", class: "btn btn-primary", data: { controller: "modal-trigger" })
+        expect(link).to have_tag("a.btn.btn-primary", text: "Link Text", with: { href: "/url", "data-controller": "modal-trigger" })
+      end
+
+      it "uses the block as the link content if provided" do
+        link = admin_link_to "/url", class: "btn btn-success", data: { controller: "batch-action" } do
+          "Link Text from Block"
+        end
+
+        expect(link).to have_tag("a.btn.btn-success", text: "Link Text from Block", with: { href: "/url", "data-controller": "batch-action" })
       end
     end
 
     context "when an instance is provided" do
-      let(:instance) { double(id: 123) }
+      let(:instance) { model.new }
 
-      before(:each) do
-        expect(admin).to receive(:to_param).with(instance).and_return(123)
-        expect(admin).to receive(:path).with(:show, { id: 123 }).and_return(url)
-        expect(self).to receive(:admin_for).with(instance).and_return(admin)
+      it "generates a link to the show action of the given admin" do
+        expect(current_admin).to receive(:instance_path).with(instance, action: :show).and_return("/admin/123")
+
+        link = admin_link_to("Instance Link", instance, admin: :test)
+        expect(link).to have_tag("a", text: "Instance Link", with: { href: "/admin/123" })
       end
 
-      it "renders a link to the given instance" do
-        expect(self).to receive(:link_to).with("link content", url, { data: { turbo_frame: "_top" } }).and_return(link)
-        expect(admin_link_to("link content", instance)).to eq(link)
+      it "uses provided action and params" do
+        expect(current_admin).to receive(:instance_path).with(instance, action: :edit, tab: :details).and_return("/admin/123/edit?tab=details")
+
+        link = admin_link_to("Instance Link", instance, admin: :test, action: :edit, params: { tab: :details })
+        expect(link).to have_tag("a", text: "Instance Link", with: { href: "/admin/123/edit?tab=details" })
       end
 
-      it "passes additional options to link_to" do
-        expect(self).to receive(:link_to).with("link content", url, { class: "btn", data: { turbo_frame: "_top" } }).and_return(link)
-        expect(admin_link_to("link content", instance, class: "btn")).to eq(link)
+      it "passes additional options to the link" do
+        link = admin_link_to("Instance Link", instance, admin: :test, class: "btn btn-success", data: { controller: "custom-action" })
+        expect(link).to have_tag("a.btn.btn-success", text: "Instance Link", with: { "data-controller": "custom-action" })
       end
 
-      it "uses the block as content if provided" do
-        blk = Proc.new {}
+      it "falls back to the current admin if not explicitly provided" do
+        expect(current_admin).to receive(:instance_path).with(instance, action: :show).and_return("/admin/123")
 
-        expect(self).to receive(:capture) { |&block|
-          expect(block).to be(blk)
-        }.and_return("captured content")
-
-        expect(self).to receive(:link_to).with("captured content", url, { data: { turbo_frame: "_top" } }).and_return(link)
-        expect(admin_link_to(instance, &blk)).to eq(link)
+        link = admin_link_to("Instance Link", instance)
+        expect(link).to have_tag("a", text: "Instance Link", with: { href: "/admin/123" })
       end
 
-      context "target admin's form is a modal" do
-        let(:form) { double(modal?: true) }
-
-        it "renders the admin link with data-controller='modal-trigger' set" do
-          expect(self).to receive(:link_to).with("link content", url, { data: { controller: "modal-trigger" } }).and_return(link)
-          expect(admin_link_to("link content", instance)).to eq(link)
-        end
+      it "raises an error if an admin can't be found" do
+        expect {
+          admin_link_to("Instance Link", instance, admin: :missing)
+        }.to raise_exception(ActionController::UrlGenerationError, "An admin could not be inferred. Please specify an admin using the :admin option.")
       end
     end
 
     context "when no instance is provided" do
-      it "renders a link using the given admin, action and params" do
-        expect(Trestle).to receive(:lookup).with(:test).and_return(admin)
-        expect(admin).to receive(:path).with(:new, { foo: "bar" }).and_return(url)
-        expect(self).to receive(:link_to).with("link content", url, { data: { turbo_frame: "_top" } }).and_return(link)
-        expect(admin_link_to("link content", action: :new, admin: :test, params: { foo: "bar" })).to eq(link)
+      it "generates a link to the index action of the given admin" do
+        expect(current_admin).to receive(:path).with(:index).and_return("/admin/test")
+        link = admin_link_to("Collection Link", admin: :test)
+        expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
       end
 
-      context "target admin's form is a modal" do
-        let(:form) { double(modal?: true) }
+      it "uses provided action and params" do
+        expect(current_admin).to receive(:path).with(:summary, scope: :test).and_return("/admin/test/summary?scope=test")
+        link = admin_link_to("Collection Link", admin: :test, action: :summary, params: { scope: :test })
+        expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test/summary?scope=test" })
+      end
 
-        it "renders the admin link with data-controller='modal-trigger' set" do
-          expect(Trestle).to receive(:lookup).with(:test).and_return(admin)
-          expect(admin).to receive(:path).with(:new, { foo: "bar" }).and_return(url)
-          expect(self).to receive(:link_to).with("link content", url, { data: { controller: "modal-trigger" } }).and_return(link)
-          expect(admin_link_to("link content", action: :new, admin: :test, params: { foo: "bar" })).to eq(link)
+      it "passes additional options to the link" do
+        link = admin_link_to("Collection Link", admin: :test, class: "btn btn-success", data: { controller: "batch-action" })
+        expect(link).to have_tag("a.btn.btn-success", text: "Collection Link", with: { "data-controller": "batch-action" })
+      end
+
+      it "uses the block as the link content if provided" do
+        link = admin_link_to admin: :test do
+          "Link Text from Block"
         end
+
+        expect(link).to have_tag("a", text: "Link Text from Block", with: { href: "/admin/test" })
+      end
+
+      it "falls back to the current admin if not explicitly provided" do
+        expect(current_admin).to receive(:path).with(:index).and_return("/admin/test")
+        link = admin_link_to("Collection Link")
+        expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
+      end
+
+      it "raises an error if the given admin can't be found" do
+        expect {
+          admin_link_to("Instance Link", admin: :missing)
+        }.to raise_exception(ActionController::UrlGenerationError, "An admin could not be inferred. Please specify an admin using the :admin option.")
       end
     end
 
-    context "when no admin or instance is provided" do
-      it "uses the current admin" do
-        expect(admin).to receive(:path).with(:new, {}).and_return(url)
-        expect(self).to receive(:link_to).with("link content", url, { data: { turbo_frame: "_top" } }).and_return(link)
-        expect(admin_link_to("link content", action: :new)).to eq(link)
+    context "when linking to a form action" do
+      let!(:admin) do
+        Trestle.resource(:test, model: model) do
+          form modal: true
+        end
       end
 
-      context "no current admin" do
-        let(:admin) { nil }
+      it "sets data-controller to 'modal-trigger'" do
+        link = admin_link_to("Instance Link", model.new)
+        expect(link).to have_tag("a", text: "Instance Link", with: { "data-controller": "modal-trigger" })
+      end
+    end
 
-        it "raises an exception" do
-          expect {
-            admin_link_to("link content", action: :new)
-          }.to raise_exception(ActionController::UrlGenerationError, "An admin could not be inferred. Please specify an admin using the :admin option.")
-        end
+    it "sets data-turbo-frame to '_top' for a regular request" do
+      link = admin_link_to("Admin Link", admin: :test)
+      expect(link).to have_tag("a", text: "Admin Link", with: { href: "/admin/test", "data-turbo-frame": "_top" })
+    end
+
+    context "from a modal request" do
+      let(:modal_request?) { true }
+
+      it "sets data-turbo-frame to 'modal' for a modal request" do
+        link = admin_link_to("Admin Link", admin: :test)
+        expect(link).to have_tag("a", text: "Admin Link", with: { href: "/admin/test", "data-turbo-frame": "modal" })
       end
     end
   end
 
-  describe "#admin_url_for" do
-    let(:instance) { double }
-    let(:param) { double }
+  describe "#admin_url_for", remove_const: true do
+    let!(:admin) { Trestle.resource(:test) }
+    let!(:alternate_admin) { Trestle.admin(:alternate) }
 
-    it "returns the path to the show action of the given admin and instance" do
-      expect(admin).to receive(:to_param).with(instance).and_return(param)
-      expect(admin).to receive(:path).with(:show, { id: param })
-      admin_url_for(instance, admin: admin)
-    end
-
-    it "returns nil if the admin passed is nil" do
-      expect(admin_url_for(instance)).to be_nil
-    end
-  end
-
-  describe "#admin_for" do
-    let(:model) { stub_const("Model", Class.new) }
-    let(:instance) { model.new }
+    let(:current_admin) { admin.new(self) }
 
     before(:each) do
-      allow(Trestle).to receive(:lookup_model).with(model).and_return(admin)
+      allow(admin).to receive(:new).with(self).and_return(current_admin)
     end
+
+    context "when given an instance" do
+      let!(:admin) { Trestle.resource(:test, model: model) }
+
+      let(:model) { stub_const("Model", Class.new) }
+      let(:instance) { model.new }
+
+      it "returns the admin path by delegating to #instance_path on the admin" do
+        expect(current_admin).to receive(:instance_path).with(instance, action: :show).and_return("/admin/123")
+        expect(admin_url_for(instance)).to eq("/admin/123")
+      end
+
+      it "passes the action and any extra params to the #instance_path method" do
+        expect(current_admin).to receive(:instance_path).with(instance, action: :edit, tab: "metadata").and_return("/admin/123/edit?tab=metadata")
+        expect(admin_url_for(instance, action: :edit, tab: "metadata")).to eq("/admin/123/edit?tab=metadata")
+      end
+
+      it "delegates to the #path method on a non-resourceful admin" do
+        alternate_instance = alternate_admin.new(self)
+        expect(alternate_admin).to receive(:new).with(self).and_return(alternate_instance)
+        expect(alternate_instance).to receive(:to_param).with(instance).and_return(123)
+        expect(alternate_instance).to receive(:path).with(:show, id: 123).and_return("/alternate/123")
+        expect(admin_url_for(instance, admin: :alternate)).to eq("/alternate/123")
+      end
+    end
+
+    context "when no instance is given" do
+      it "returns the path using by delegating to #path on the admin" do
+        expect(current_admin).to receive(:path).with(:index).and_return("/admin")
+        expect(admin_url_for(action: :index)).to eq("/admin")
+      end
+
+      it "returns the path to the index action by default" do
+        expect(current_admin).to receive(:path).with(:index).and_return("/admin")
+        expect(admin_url_for).to eq("/admin")
+      end
+
+      it "passes additional options to the call to #path" do
+        expect(current_admin).to receive(:path).with(:index, scope: :limited).and_return("/admin?scope=limited")
+        expect(admin_url_for(action: :index, scope: :limited)).to eq("/admin?scope=limited")
+      end
+
+      it "uses the specified admin when passed as a symbol" do
+        expect(alternate_admin).to receive(:path).with(:index).and_return("/alternate")
+        expect(admin_url_for(action: :index, admin: :alternate)).to eq("/alternate")
+      end
+
+      it "uses the specified admin when passed as a class" do
+        expect(alternate_admin).to receive(:path).with(:index).and_return("/alternate")
+        expect(admin_url_for(action: :index, admin: alternate_admin)).to eq("/alternate")
+      end
+    end
+
+    context "when the given admin is not found" do
+      it "returns nil by default" do
+        expect(admin_url_for(admin: :missing)).to be nil
+      end
+
+      it "raises an exception when raise: true passed" do
+        expect {
+          admin_url_for(admin: :missing, raise: true)
+        }.to raise_exception(ActionController::UrlGenerationError, "An admin could not be inferred. Please specify an admin using the :admin option.")
+      end
+    end
+  end
+
+  describe "#admin_for", remove_const: true do
+    let!(:admin) { Trestle.resource(:test, model: model) }
+
+    let(:model) { stub_const("Model", Class.new) }
+
+    let(:instance) { model.new }
+    let(:unregistered) { double }
 
     it "looks up the model's admin in the registry" do
       expect(admin_for(instance)).to eq(admin)
+    end
+
+    it "returns nil if the model is not found in the registry" do
+      expect(admin_for(unregistered)).to be nil
     end
   end
 end

--- a/spec/trestle/helpers/url_helper_spec.rb
+++ b/spec/trestle/helpers/url_helper_spec.rb
@@ -78,13 +78,13 @@ describe Trestle::UrlHelper, type: :helper do
 
     context "when no instance is provided" do
       it "generates a link to the index action of the given admin" do
-        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin/test")
+        expect(current_admin).to receive(:path).with(:index, {}).and_return("/admin/test")
         link = admin_link_to("Collection Link", admin: :test)
         expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
       end
 
       it "uses provided action and params" do
-        expect(current_admin).to receive(:path).with(:summary, scope: :test).and_return("/admin/test/summary?scope=test")
+        expect(current_admin).to receive(:path).with(:summary, { scope: :test }).and_return("/admin/test/summary?scope=test")
         link = admin_link_to("Collection Link", admin: :test, action: :summary, params: { scope: :test })
         expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test/summary?scope=test" })
       end
@@ -103,7 +103,7 @@ describe Trestle::UrlHelper, type: :helper do
       end
 
       it "falls back to the current admin if not explicitly provided" do
-        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin/test")
+        expect(current_admin).to receive(:path).with(:index, {}).and_return("/admin/test")
         link = admin_link_to("Collection Link")
         expect(link).to have_tag("a", text: "Collection Link", with: { href: "/admin/test" })
       end
@@ -178,34 +178,34 @@ describe Trestle::UrlHelper, type: :helper do
         alternate_instance = alternate_admin.new(self)
         expect(alternate_admin).to receive(:new).with(self).and_return(alternate_instance)
         expect(alternate_instance).to receive(:to_param).with(instance).and_return(123)
-        expect(alternate_instance).to receive(:path).with(:show, id: 123).and_return("/alternate/123")
+        expect(alternate_instance).to receive(:path).with(:show, { id: 123 }).and_return("/alternate/123")
         expect(admin_url_for(instance, admin: :alternate)).to eq("/alternate/123")
       end
     end
 
     context "when no instance is given" do
       it "returns the path using by delegating to #path on the admin" do
-        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin")
+        expect(current_admin).to receive(:path).with(:index, {}).and_return("/admin")
         expect(admin_url_for(action: :index)).to eq("/admin")
       end
 
       it "returns the path to the index action by default" do
-        expect(current_admin).to receive(:path).with(:index, **{}).and_return("/admin")
+        expect(current_admin).to receive(:path).with(:index, {}).and_return("/admin")
         expect(admin_url_for).to eq("/admin")
       end
 
       it "passes additional options to the call to #path" do
-        expect(current_admin).to receive(:path).with(:index, scope: :limited).and_return("/admin?scope=limited")
+        expect(current_admin).to receive(:path).with(:index, { scope: :limited }).and_return("/admin?scope=limited")
         expect(admin_url_for(action: :index, scope: :limited)).to eq("/admin?scope=limited")
       end
 
       it "uses the specified admin when passed as a symbol" do
-        expect(alternate_admin).to receive(:path).with(:index, **{}).and_return("/alternate")
+        expect(alternate_admin).to receive(:path).with(:index, {}).and_return("/alternate")
         expect(admin_url_for(action: :index, admin: :alternate)).to eq("/alternate")
       end
 
       it "uses the specified admin when passed as a class" do
-        expect(alternate_admin).to receive(:path).with(:index, **{}).and_return("/alternate")
+        expect(alternate_admin).to receive(:path).with(:index, {}).and_return("/alternate")
         expect(admin_url_for(action: :index, admin: alternate_admin)).to eq("/alternate")
       end
     end

--- a/spec/trestle/registry_spec.rb
+++ b/spec/trestle/registry_spec.rb
@@ -81,6 +81,13 @@ describe Trestle::Registry, remove_const: true do
       end
     end
 
+    context "given an instance of an admin class" do
+      it "returns the admin instance" do
+        admin = TestAdmin.new(self)
+        expect(registry.lookup(admin)).to eq(admin)
+      end
+    end
+
     context "given a string or symbol" do
       it "returns the admin class corresponding to the given string/symbol" do
         expect(registry.lookup(:test)).to eq(TestAdmin)

--- a/spec/trestle/resource/toolbar_spec.rb
+++ b/spec/trestle/resource/toolbar_spec.rb
@@ -9,6 +9,8 @@ describe Trestle::Resource::Toolbar::Builder do
   subject(:builder) { Trestle::Resource::Toolbar::Builder.new(template) }
 
   before(:each) do
+    allow(Trestle).to receive(:lookup).with(admin).and_return(admin)
+
     allow(admin).to receive(:t).with("buttons.new", default: "New %{model_name}").and_return("New Resource")
     allow(admin).to receive(:t).with("buttons.save", default: "Save %{model_name}").and_return("Save Resource")
     allow(admin).to receive(:t).with("buttons.delete", default: "Delete %{model_name}").and_return("Delete Resource")

--- a/spec/trestle/toolbar/item_spec.rb
+++ b/spec/trestle/toolbar/item_spec.rb
@@ -44,7 +44,7 @@ end
 shared_examples "a toolbar item with a dropdown" do |tag, attrs|
   include_context "template"
 
-  let(:admin) { double }
+  let(:admin) { double(root_action: :index) }
 
   let(:options) { {} }
 
@@ -58,6 +58,7 @@ shared_examples "a toolbar item with a dropdown" do |tag, attrs|
   end
 
   before(:each) {
+    allow(Trestle).to receive(:lookup).with(admin).and_return(admin)
     allow(Trestle).to receive(:lookup).with(:test).and_return(admin)
     allow(admin).to receive(:path).and_return("/admin/test")
   }
@@ -109,7 +110,7 @@ shared_examples "a toolbar item with a split dropdown" do |tag, attrs|
 end
 
 describe Trestle::Toolbar::Button do
-  subject(:button) { Trestle::Toolbar::Button.new(template, "Label", options, &block) }
+  subject(:button) { Trestle::Toolbar::Button.new(template, "Label", **options, &block) }
 
   let(:options) { {} }
   let(:block) { nil }
@@ -119,7 +120,7 @@ describe Trestle::Toolbar::Button do
 end
 
 describe Trestle::Toolbar::Link do
-  subject(:link) { Trestle::Toolbar::Link.new(template, "Label", "#", options, &block) }
+  subject(:link) { Trestle::Toolbar::Link.new(template, "Label", "#", **options, &block) }
 
   let(:options) { {} }
   let(:block) { nil }
@@ -129,7 +130,7 @@ describe Trestle::Toolbar::Link do
 end
 
 describe Trestle::Toolbar::Dropdown do
-  subject(:dropdown) { Trestle::Toolbar::Dropdown.new(template, "Label", options, &block) }
+  subject(:dropdown) { Trestle::Toolbar::Dropdown.new(template, "Label", **options, &block) }
 
   let(:options) { {} }
   let(:block) { nil }


### PR DESCRIPTION
The URL helpers, and in particular `admin_link_to` has long been a particularly inelegant part of the codebase. This PR rewrites the `admin_link_to` and `admin_url_for` helpers and their specs, adding kwargs and bringing their supported behaviors in line with each other (`admin_link_to` now calls `admin_url_for` in most cases).