### PR TITLE
Combine .app-main and #main turbo-frame

### DIFF
--- a/app/views/layouts/trestle/admin.html.erb
+++ b/app/views/layouts/trestle/admin.html.erb
@@ -43,11 +43,9 @@
       <div class="app-container">
         <%= render "trestle/shared/header" %>
 
-        <main class="app-main">
-          <turbo-frame id="main" data-turbo-action="advance">
-            <%= yield %>
-          </turbo-frame>
-        </main>
+        <turbo-frame class="app-main" id="main" data-turbo-action="advance">
+          <%= yield %>
+        </turbo-frame>
 
         <%= render "trestle/shared/footer" %>
       </div>


### PR DESCRIPTION
A separate turbo-frame child element caused issues when elements expect to be within the .app-main flex container.