### PR TITLE
Temporarily pin turbo-rails to 2.0.7 for Ruby 2.6 / Rails 6.x tests

### DIFF
--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -17,5 +17,6 @@ end
 gem 'rails', '~> 6.0.0'
 gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
+gem 'turbo-rails', '2.0.7'
 
 gemspec path: "../"

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -17,5 +17,6 @@ end
 gem 'rails', '~> 6.1.0'
 gem 'sprockets-rails'
 gem 'sqlite3', '~> 1.4'
+gem 'turbo-rails', '2.0.7'
 
 gemspec path: "../"


### PR DESCRIPTION
Pending resolution of https://github.com/hotwired/turbo-rails/issues/681 and [@hotwired/turbo-rails#682](https://github.com/hotwired/turbo-rails/pull/682).