### PR TITLE
Remove block passing / layout support from 'trestle/flash/alert' partial

### DIFF
--- a/app/views/trestle/flash/_alert.html.erb
+++ b/app/views/trestle/flash/_alert.html.erb
@@ -12,6 +12,8 @@
       <p><%= alert[:message] %></p>
     <% end %>
 
-    <%= yield if block_given? %>
+    <% if local_assigns[:errors] %>
+      <%= render "trestle/flash/debug", errors: errors %>
+    <% end %>
   </div>
 </div>

--- a/app/views/trestle/flash/_flash.html.erb
+++ b/app/views/trestle/flash/_flash.html.erb
@@ -1,7 +1,10 @@
 <% if flash[:message] -%>
-  <%= render "trestle/flash/alert", html_class: "alert-success", icon: icon("alert-icon far fa-check-circle"), alert: normalize_flash_alert(flash[:message]) %>
+  <%= render "trestle/flash/alert", html_class: "alert-success",
+                                    icon: icon("alert-icon far fa-check-circle"),
+                                    alert: normalize_flash_alert(flash[:message]) %>
 <% elsif flash[:error] -%>
-  <%= render layout: "trestle/flash/alert", locals: { html_class: "alert-danger", icon: icon("alert-icon far fa-times-circle"), alert: normalize_flash_alert(flash[:error]) } do %>
-    <%= render "trestle/flash/debug", errors: Trestle::DebugErrors.new(instance.errors) if debug_form_errors? %>
-  <% end %>
+  <%= render "trestle/flash/alert", html_class: "alert-danger",
+                                    icon: icon("alert-icon far fa-times-circle"),
+                                    alert: normalize_flash_alert(flash[:error]),
+                                    errors: (Trestle::DebugErrors.new(instance.errors) if debug_form_errors?) %>
 <% end -%>

--- a/sandbox/app/admin/components/alerts_admin.rb
+++ b/sandbox/app/admin/components/alerts_admin.rb
@@ -4,4 +4,12 @@ Trestle.admin(:alerts, scope: Components) do
       item :alerts, icon: "fas fa-exclamation-circle", priority: 1
     end
   end
+
+  helper do
+    def alert_message(html_class)
+      <<-HTML.html_safe
+        This custom alert has the <code>#{html_class}</code> class. This is the <a href="#">Link style</a>.
+      HTML
+    end
+  end
 end

--- a/sandbox/app/admin/components/theme_admin.rb
+++ b/sandbox/app/admin/components/theme_admin.rb
@@ -4,4 +4,12 @@ Trestle.admin(:theme, scope: Components) do
       item :theme, icon: "fas fa-palette", priority: 8
     end
   end
+
+  helper do
+    def alert_message(html_class)
+      <<-HTML.html_safe
+        This custom alert has the <code>#{html_class}</code> class. This is the <a href="#">Link style</a>.
+      HTML
+    end
+  end
 end

--- a/sandbox/app/views/admin/components/alerts/index.html.erb
+++ b/sandbox/app/views/admin/components/alerts/index.html.erb
@@ -8,12 +8,29 @@
         <p>These alert types are generated internally by Trestle within resourceful admins.</p>
       <% end %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-success", icon: icon("alert-icon far fa-check-circle"), alert: { title: admin.t("flash.create.success.title"), message: admin.t("flash.create.success.message", lowercase_model_name: "resource") } %>
-      <%= render "trestle/flash/alert", html_class: "alert-danger", icon: icon("alert-icon far fa-times-circle"), alert: { title: admin.t("flash.create.failure.title"), message: admin.t("flash.create.failure.message", lowercase_model_name: "resource") } %>
+      <%= render "trestle/flash/alert", html_class: "alert-success",
+                                        icon: icon("alert-icon far fa-check-circle"),
+                                        alert: {
+                                          title: admin.t("flash.create.success.title"),
+                                          message: admin.t("flash.create.success.message",
+                                          lowercase_model_name: "resource")
+                                        } %>
 
-      <%= render layout:  "trestle/flash/alert", locals: { html_class: "alert-danger", icon: icon("alert-icon far fa-times-circle"), alert: { title: admin.t("flash.create.failure.title"), message: admin.t("flash.create.failure.message", lowercase_model_name: "resource") } } do %>
-        <%= render "trestle/flash/debug", errors: { field: "is required", another: "is already taken" } %>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-danger",
+                                        icon: icon("alert-icon far fa-times-circle"),
+                                        alert: {
+                                          title: admin.t("flash.create.failure.title"),
+                                          message: admin.t("flash.create.failure.message",
+                                          lowercase_model_name: "resource")
+                                        } %>
+
+      <%= render "trestle/flash/alert", html_class: "alert-danger",
+                                        icon: icon("alert-icon far fa-times-circle"),
+                                        alert: {
+                                          title: admin.t("flash.create.failure.title"),
+                                          message: admin.t("flash.create.failure.message", lowercase_model_name: "resource")
+                                        },
+                                        errors: { field: "is required", another: "is already taken" } %>
     <% end %>
 
     <%= container do |c| %>
@@ -21,29 +38,47 @@
         <h2>Custom alerts</h2>
       <% end %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-primary", icon: icon("alert-icon fas fa-bell"), alert: { title: "Primary" } do %>
-        <p>This custom alert has the <code>.alert-primary</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-primary",
+                                        icon: icon("alert-icon fas fa-bell"),
+                                        alert: {
+                                          title: "Primary",
+                                          message: alert_message(".alert-primary")
+                                        } %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-secondary", icon: icon("alert-icon fas fa-download"), alert: { title: "Secondary" } do %>
-        <p>This custom alert has the <code>.alert-secondary</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-secondary",
+                                        icon: icon("alert-icon fas fa-download"),
+                                        alert: {
+                                          title: "Secondary",
+                                          message: alert_message(".alert-secondary")
+                                        } %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-info", icon: icon("alert-icon fas fa-exclamation"), alert: { title: "Info" } do %>
-        <p>This custom alert has the <code>.alert-info</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-info",
+                                        icon: icon("alert-icon fas fa-exclamation"),
+                                        alert: {
+                                          title: "Info",
+                                          message: alert_message(".alert-info")
+                                        } %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-warning", icon: icon("alert-icon fas fa-radiation-alt"), alert: { title: "Warning" } do %>
-        <p>This custom alert has the <code>.alert-warning</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-warning",
+                                        icon: icon("alert-icon fas fa-radiation-alt"),
+                                        alert: {
+                                          title: "Warning",
+                                          message: alert_message(".alert-warning")
+                                        } %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-light", icon: icon("alert-icon far fa-sun"), alert: { title: "Light" } do %>
-        <p>This custom alert has the <code>.alert-light</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-light",
+                                        icon: icon("alert-icon fas fa-sun"),
+                                        alert: {
+                                          title: "Light",
+                                          message: alert_message(".alert-light")
+                                        } %>
 
-      <%= render "trestle/flash/alert", html_class: "alert-dark", icon: icon("alert-icon far fa-moon"), alert: { title: "Dark" } do %>
-        <p>This custom alert has the <code>.alert-dark</code> class. This is the <a href="#">Link style</a>.</p>
-      <% end %>
+      <%= render "trestle/flash/alert", html_class: "alert-dark",
+                                        icon: icon("alert-icon far fa-moon"),
+                                        alert: {
+                                          title: "Dark",
+                                          message: alert_message(".alert-dark")
+                                        } %>
     <% end %>
   </div>
 <% end %>

--- a/sandbox/app/views/admin/components/theme/_alerts.html.erb
+++ b/sandbox/app/views/admin/components/theme/_alerts.html.erb
@@ -3,11 +3,17 @@
     <h2 class="m-0">Alerts</h2>
   </header>
 
-  <%= render "trestle/flash/alert", html_class: "alert-primary", icon: icon("alert-icon fas fa-bell"), alert: { title: "Primary" } do %>
-    <p>This custom alert has the <code>.alert-primary</code> class. This is the <a href="#">Link style</a>.</p>
-  <% end %>
+  <%= render "trestle/flash/alert", html_class: "alert-primary",
+                                    icon: icon("alert-icon fas fa-bell"),
+                                    alert: {
+                                      title: "Primary",
+                                      message: alert_message(".alert-primary")
+                                    } %>
 
-  <%= render "trestle/flash/alert", html_class: "alert-secondary", icon: icon("alert-icon fas fa-download"), alert: { title: "Secondary" } do %>
-    <p>This custom alert has the <code>.alert-secondary</code> class. This is the <a href="#">Link style</a>.</p>
-  <% end %>
+  <%= render "trestle/flash/alert", html_class: "alert-secondary",
+                                    icon: icon("alert-icon fas fa-download"),
+                                    alert: {
+                                      title: "Secondary",
+                                      message: alert_message(".alert-secondary")
+                                    } %>
 <% end %>


### PR DESCRIPTION
In Rails partials, `block_given?` always returns true, meaning the `trestle/flash/alert` partial previously always called `yield`, occasionally causing duplicated content.

This PR removes support for using this template as a partial layout. While this does remove some flexibility, it solves the above problem and makes the usage of the partial simpler, clearer and more consistent.