### PR TITLE
Ensure scopes continue linking to scope even when currently active

### DIFF
--- a/app/views/trestle/resource/_scopes.html.erb
+++ b/app/views/trestle/resource/_scopes.html.erb
@@ -6,7 +6,7 @@
       <ul class="scope-list">
         <% scopes.each do |scope| %>
           <li>
-            <%= link_to persistent_params.merge(scope: (scope unless scope.active?(params))), class: ["scope", ("active" if scope.active?(params))] do %>
+            <%= link_to persistent_params.merge(scope: scope), class: ["scope", ("active" if scope.active?(params))] do %>
               <strong><%= scope.label %></strong>
               <% if scope.count? %>(<%= number_with_delimiter(scope.count(admin.collection(params))) %>)<% end %>
             <% end %>


### PR DESCRIPTION
Previously, scope links behaved as a 'toggle' link, deactivating the scope if clicked on again. While I can see my own previous logic in implementing it this way, I think it makes the most sense to always link to the scope.

If there happens to be a demand for the previous behavior, then it could be made explicit with an option on the scopes block.