### PR TITLE
Turbo frame refinements

### DIFF
--- a/app/helpers/trestle/turbo/frame_helper.rb
+++ b/app/helpers/trestle/turbo/frame_helper.rb
@@ -1,34 +1,6 @@
 module Trestle
   module Turbo
     module FrameHelper
-      # Renders a <turbo-frame> container for an index view. An index turbo frame
-      # is by default reloadable (it will be refreshed by the `reload` turbo stream
-      # action), and has the Turbo visit behavior always set to "advance".
-      #
-      # attributes - Additional HTML attributes to add to the <turbo-frame> tag
-      #
-      # Examples
-      #
-      #   <%= index_turbo_frame do %> ...
-      #
-      #   <%= index_turbo_frame id: "articles-index",
-      #                         data: {
-      #                           reloadable_url_value: admin.path(:articles)
-      #                         } do %> ...
-      #
-      # Returns a HTML-safe String.
-      def index_turbo_frame(**attributes, &block)
-        defaults = {
-          id: "index",
-          data: {
-            controller: "reloadable",
-            turbo_action: "advance"
-          }
-        }
-
-        tag.turbo_frame(**defaults.merge(attributes), &block)
-      end
-
       # Renders a <turbo-frame> container for an instance/resource view. A resource
       # turbo frame sets its DOM id from the given instance and has a default target of
       # "_top" (except for modal requests).
@@ -52,6 +24,15 @@ module Trestle
         }
 
         tag.turbo_frame(**defaults.merge(attributes), &block)
+      end
+
+      # [DEPRECATED]
+      #
+      # The #content turbo-frame found in app/views/trestle/application/_layout.html.erb
+      # is now used as a common top-level hook for the 'reloadable' Stimulus controller.
+      def index_turbo_frame(**attributes, &block)
+        Trestle.deprecator.warn("The index_turbo_frame helper is deprecated and will be removed in future versions of Trestle.")
+        yield
       end
     end
   end

--- a/app/helpers/trestle/turbo/frame_helper.rb
+++ b/app/helpers/trestle/turbo/frame_helper.rb
@@ -33,6 +33,7 @@ module Trestle
       def index_turbo_frame(**attributes, &block)
         Trestle.deprecator.warn("The index_turbo_frame helper is deprecated and will be removed in future versions of Trestle.")
         yield
+        nil
       end
     end
   end

--- a/app/views/layouts/trestle/admin.html.erb
+++ b/app/views/layouts/trestle/admin.html.erb
@@ -43,9 +43,9 @@
       <div class="app-container">
         <%= render "trestle/shared/header" %>
 
-        <turbo-frame class="app-main" id="main" data-turbo-action="advance">
+        <div class="app-main">
           <%= yield %>
-        </turbo-frame>
+        </div>
 
         <%= render "trestle/shared/footer" %>
       </div>

--- a/app/views/layouts/trestle/admin.turbo_stream.erb
+++ b/app/views/layouts/trestle/admin.turbo_stream.erb
@@ -1,4 +1,0 @@
-<%= yield %>
-
-<%= turbo_stream.flash unless modal_request? %>
-<%= turbo_stream.reload %>

--- a/app/views/trestle/application/_layout.html.erb
+++ b/app/views/trestle/application/_layout.html.erb
@@ -6,19 +6,21 @@
       <%= render "trestle/flash/flash" %>
     </turbo-frame>
 
-    <%= render "utilities" %>
-    <%= render "tabs", data: { controller: "tabs tab-errors" } %>
+    <turbo-frame id="content" data-controller="reloadable" data-turbo-action="advance">
+      <%= render "utilities" %>
+      <%= render "tabs", data: { controller: "tabs tab-errors" } %>
 
-    <% if local_assigns.fetch(:wrapper, true) %>
-      <%= container do |c| %>
+      <% if local_assigns.fetch(:wrapper, true) %>
+        <%= container do |c| %>
+          <%= yield %>
+
+          <% c.sidebar do %>
+            <%= content_for(:sidebar) %>
+          <% end if content_for?(:sidebar) %>
+        <% end %>
+      <% else %>
         <%= yield %>
-
-        <% c.sidebar do %>
-          <%= content_for(:sidebar) %>
-        <% end if content_for?(:sidebar) %>
       <% end %>
-    <% else %>
-      <%= yield %>
-    <% end %>
+    </turbo-frame>
   </div>
 </turbo-frame>

--- a/app/views/trestle/application/_layout.html.erb
+++ b/app/views/trestle/application/_layout.html.erb
@@ -1,22 +1,24 @@
-<%= render "header", hide_breadcrumbs: local_assigns.fetch(:hide_breadcrumbs, false) if local_assigns.fetch(:header, true) %>
+<turbo-frame id="main" data-turbo-action="advance">
+  <%= render "header", hide_breadcrumbs: local_assigns.fetch(:hide_breadcrumbs, false) if local_assigns.fetch(:header, true) %>
 
-<div class="main-content-area" data-scroll-target>
-  <turbo-frame id="flash">
-    <%= render "trestle/flash/flash" %>
-  </turbo-frame>
+  <div class="main-content-area" data-scroll-target>
+    <turbo-frame id="flash">
+      <%= render "trestle/flash/flash" %>
+    </turbo-frame>
 
-  <%= render "utilities" %>
-  <%= render "tabs", data: { controller: "tabs tab-errors" } %>
+    <%= render "utilities" %>
+    <%= render "tabs", data: { controller: "tabs tab-errors" } %>
 
-  <% if local_assigns.fetch(:wrapper, true) %>
-    <%= container do |c| %>
+    <% if local_assigns.fetch(:wrapper, true) %>
+      <%= container do |c| %>
+        <%= yield %>
+
+        <% c.sidebar do %>
+          <%= content_for(:sidebar) %>
+        <% end if content_for?(:sidebar) %>
+      <% end %>
+    <% else %>
       <%= yield %>
-
-      <% c.sidebar do %>
-        <%= content_for(:sidebar) %>
-      <% end if content_for?(:sidebar) %>
     <% end %>
-  <% else %>
-    <%= yield %>
-  <% end %>
-</div>
+  </div>
+</turbo-frame>

--- a/app/views/trestle/resource/create.turbo_stream.erb
+++ b/app/views/trestle/resource/create.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.replace admin.build_instance({}, params), template: "trestle/resource/#{instance.persisted? ? "show" : "new"}" %>
+<%= turbo_stream.reload if modal_request? && instance.persisted? %>

--- a/app/views/trestle/resource/destroy.turbo_stream.erb
+++ b/app/views/trestle/resource/destroy.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.close_modal instance %>
+<%= turbo_stream.flash %>
+<%= turbo_stream.reload %>

--- a/app/views/trestle/resource/index.html.erb
+++ b/app/views/trestle/resource/index.html.erb
@@ -14,19 +14,17 @@
 <% end if admin.scopes.any? %>
 
 <%= render layout: "layout" do %>
-  <%= index_turbo_frame do %>
-    <% if hook?("resource.index.header") %>
-      <header class="main-content-header">
-        <%= hook("resource.index.header") %>
-      </header>
-    <% end %>
-
-    <%= render "trestle/table/table", table: admin.table, collection: collection %>
-
-    <footer class="main-content-footer">
-      <%= hook("resource.index.footer") %>
-
-      <%= pagination collection: collection, entry_name: admin.model_name %>
-    </footer>
+  <% if hook?("resource.index.header") %>
+    <header class="main-content-header">
+      <%= hook("resource.index.header") %>
+    </header>
   <% end %>
+
+  <%= render "trestle/table/table", table: admin.table, collection: collection %>
+
+  <footer class="main-content-footer">
+    <%= hook("resource.index.footer") %>
+
+    <%= pagination collection: collection, entry_name: admin.model_name %>
+  </footer>
 <% end %>

--- a/app/views/trestle/resource/update.turbo_stream.erb
+++ b/app/views/trestle/resource/update.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.replace instance, template: "trestle/resource/show" %>
+<%= turbo_stream.reload if modal_request? %>


### PR DESCRIPTION
The previous iteration of the turbo frame setup, and the attempted fixes in #494, #495 and #497 had some drawbacks still. One of the main ones being that the scopes were outside of the index turbo frame, so scope counts were not being updated when rows were added, deleted or filtered via a search.

This PR:

* Backs out #497 and separates `.app-main` from the `#main` turbo-frame (it does not feel right for a turbo frame to be a structural element)
* Moves the `#main` turbo-frame inside `app/views/trestle/application/_layout.html.erb` so that it can be bypassed if required.
* Introduces a new `#content` turbo-frame within `app/views/trestle/application/_layout.html.erb` that wraps utilities, tabs and content (but not the flash).
* Deprecates the `#index_turbo_frame` helper and removes its usage from the templates. Existing usage should continue to work, essentially functioning as a no-op.
* Removes the turbo stream layout file, preferring targeted turbo stream actions within each create/update/destroy response.