### PR TITLE
Added ability to exclude form fields through the DSL

### DIFF
--- a/lib/trestle/adapters/active_record_adapter.rb
+++ b/lib/trestle/adapters/active_record_adapter.rb
@@ -49,7 +49,7 @@ module Trestle
 
       def default_form_attributes
         default_attributes.reject do |attribute|
-          primary_key?(attribute) || inheritance_column?(attribute) || counter_cache_column?(attribute)
+          primary_key?(attribute) || inheritance_column?(attribute) || counter_cache_column?(attribute) || excluded_attribute?(attribute)
         end
       end
 
@@ -78,6 +78,10 @@ module Trestle
 
       def counter_cache_column?(attribute)
         attribute.name.to_s.end_with?("_count")
+      end
+
+      def excluded_attribute?(attribute)
+        admin.excluded_form_attributes.include?(attribute.name.to_sym)
       end
 
       def array_column?(column)

--- a/lib/trestle/admin.rb
+++ b/lib/trestle/admin.rb
@@ -149,6 +149,10 @@ module Trestle
         @additional_routes ||= []
       end
 
+      def excluded_form_attributes
+        @excluded_form_attributes ||= []
+      end
+
       def routes
         admin = self
 

--- a/lib/trestle/admin/builder.rb
+++ b/lib/trestle/admin/builder.rb
@@ -95,6 +95,12 @@ module Trestle
         end
       end
 
+      def exclude_form_attributes(*attributes)
+        attributes.each do |attribute|
+          @admin.excluded_form_attributes << attribute.to_sym
+        end
+      end
+
     protected
       def normalize_table_options(name, options)
         if name.is_a?(Hash)

--- a/spec/dummy/app/admin/automatic_excluding_admin.rb
+++ b/spec/dummy/app/admin/automatic_excluding_admin.rb
@@ -1,0 +1,37 @@
+Trestle.resource(:automatic_excluding, model: Post) do
+  menu do
+    item :automatic_excluding, icon: "fa fa-star"
+  end
+
+  exclude_form_attributes :created_at, :updated_at
+
+  # Customize the table columns shown on the index view.
+  #
+  # table do
+  #   column :name
+  #   column :created_at, align: :center
+  #   actions
+  # end
+
+  # Customize the form fields shown on the new/edit views.
+  #
+  # form do |post|
+  #   text_field :name
+  #
+  #   row do
+  #     col(xs: 6) { datetime_field :updated_at }
+  #     col(xs: 6) { datetime_field :created_at }
+  #   end
+  # end
+
+  # By default, all parameters passed to the update and create actions will be
+  # permitted. If you do not have full trust in your users, you should explicitly
+  # define the list of permitted parameters.
+  #
+  # For further information, see the Rails documentation on Strong Parameters:
+  #   http://guides.rubyonrails.org/action_controller_overview.html#strong-parameters
+  #
+  # params do |params|
+  #   params.require(:post).permit(:name, ...)
+  # end
+end

--- a/spec/feature/automatic_resource_spec.rb
+++ b/spec/feature/automatic_resource_spec.rb
@@ -29,6 +29,24 @@ feature 'Automatic resources', js: true do
     visit '/admin/automatic'
     click_link "1"
 
+    expect(page).to have_content("Created at")
+    expect(page).to have_content("Updated at")
+
+    fill_in "Title", with: "Updated Title"
+    click_button "Save Post"
+
+    expect(page).to have_content("The post was successfully updated.")
+  end
+
+  scenario 'update record while excluding attributes' do
+    create_test_post
+
+    visit '/admin/automatic_excluding'
+    click_link "1"
+
+    expect(page).not_to have_content("Created at")
+    expect(page).not_to have_content("Updated at")
+
     fill_in "Title", with: "Updated Title"
     click_button "Save Post"
 


### PR DESCRIPTION
This PR adds the ability to exclude certain form fields when using the automatic form generator through the DSL.

This is an alternative take on #416 where it was done globally through the configuration.