### PR TITLE
[PoC] Add ability to exclude fields from automatic forms and tables

### DIFF
--- a/lib/trestle/admin/builder.rb
+++ b/lib/trestle/admin/builder.rb
@@ -49,7 +49,12 @@ module Trestle
 
       def table(name_or_options={}, options={}, &block)
         name, options = normalize_table_options(name_or_options, options)
-        admin.tables[name] = Table::Builder.build(options, &block)
+
+        if block_given?
+          admin.tables[name] = Table::Builder.build(options, &block)
+        else
+          admin.tables[name] = Table::Automatic.new(admin, options)
+        end
       end
 
       def form(options={}, &block)

--- a/lib/trestle/form/automatic.rb
+++ b/lib/trestle/form/automatic.rb
@@ -2,8 +2,11 @@ module Trestle
   class Form
     class Automatic < Form
       def initialize(admin, options={})
+        @admin = admin
+        form = self
+
         super(options) do |instance|
-          admin.default_form_attributes.each do |attribute|
+          form.attributes.each do |attribute|
             if attribute.array?
               if [:string, :text].include?(attribute.type)
                 select attribute.name, nil, {}, { multiple: true, data: { tags: true, select_on_close: true }}
@@ -45,6 +48,17 @@ module Trestle
             end
           end
         end
+      end
+
+      def attributes
+        @admin.default_form_attributes.reject { |attribute|
+          exclude?(attribute.name)
+        }
+      end
+
+    private
+      def exclude?(field)
+        Array(options[:exclude]).include?(field)
       end
     end
   end

--- a/lib/trestle/table/automatic.rb
+++ b/lib/trestle/table/automatic.rb
@@ -1,8 +1,8 @@
 module Trestle
   class Table
     class Automatic < Table
-      def initialize(admin)
-        super(sortable: true, admin: admin)
+      def initialize(admin, options={})
+        super(options.merge(sortable: true, admin: admin))
       end
 
       def columns

--- a/lib/trestle/table/automatic.rb
+++ b/lib/trestle/table/automatic.rb
@@ -10,7 +10,7 @@ module Trestle
       end
 
       def content_columns
-        admin.default_table_attributes.map.with_index do |attribute, index|
+        attributes.map.with_index do |attribute, index|
           case attribute.type
           when :association
             Column.new(attribute.association_name, sort: false)
@@ -29,6 +29,17 @@ module Trestle
 
       def actions_column
         ActionsColumn.new
+      end
+
+    private
+      def attributes
+        admin.default_table_attributes.reject { |attribute|
+          exclude?(attribute.name)
+        }
+      end
+
+      def exclude?(field)
+        Array(options[:exclude]).include?(field)
       end
     end
   end


### PR DESCRIPTION
This is a proof of concept PR for an alternative way to support excluding fields from automatic tables and forms, as seen in #517 and #416.

It adds the ability to specify the `:exclude` option when defining an automatic table or form (i.e. without a block).

```ruby
Trestle.resource(:articles) do
  table exclude: [:updated_at, :created_at]
  form exclude: [:updated_at, :created_at]
end
```

The advantage I see to this approach is that it confines the exclusion logic to the automatic form and table classes where it is most relevant. One disadvantage perhaps is that it is slightly harder to re-use specific exclusions between resources via adapter methods/modules.

A logical next step would be to add global configuration options for the default excluded fields (e.g. `Trestle.config.default_table_exclusions` / `Trestle.config.default_form_exclusions`).