### PR TITLE
Add ability to disable default form wrapper

### DIFF
--- a/app/views/trestle/resource/edit.html.erb
+++ b/app/views/trestle/resource/edit.html.erb
@@ -15,6 +15,6 @@
 
 <%= resource_turbo_frame(instance) do %>
   <%= trestle_form_for instance, url: admin.actions.include?(:update) ? admin.instance_path(instance, action: :update) : "#", method: :patch do |f| %>
-    <%= render partial: "form", layout: modal_request? ? "modal" : "layout" %>
+    <%= render partial: "form", layout: modal_request? ? "modal" : "layout", locals: { wrapper: admin.form.wrapper? } %>
   <% end %>
 <% end %>

--- a/app/views/trestle/resource/new.html.erb
+++ b/app/views/trestle/resource/new.html.erb
@@ -14,6 +14,6 @@
 
 <%= resource_turbo_frame(instance) do %>
   <%= trestle_form_for instance, url: admin.path(:create), method: :post do |f| %>
-    <%= render partial: "form", layout: modal_request? ? "modal" : "layout" %>
+    <%= render partial: "form", layout: modal_request? ? "modal" : "layout", locals: { wrapper: admin.form.wrapper? } %>
   <% end %>
 <% end %>

--- a/app/views/trestle/resource/show.html.erb
+++ b/app/views/trestle/resource/show.html.erb
@@ -15,6 +15,6 @@
 
 <%= resource_turbo_frame(instance) do %>
   <%= trestle_form_for instance, url: admin.actions.include?(:update) ? admin.instance_path(instance, action: :update) : "#", method: :patch do |f| %>
-    <%= render partial: "form", layout: modal_request? ? "modal" : "layout" %>
+    <%= render partial: "form", layout: modal_request? ? "modal" : "layout", locals: { wrapper: admin.form.wrapper? } %>
   <% end %>
 <% end %>

--- a/lib/trestle/form.rb
+++ b/lib/trestle/form.rb
@@ -26,6 +26,10 @@ module Trestle
       options[:modal]
     end
 
+    def wrapper?
+      options.fetch(:wrapper, true)
+    end
+
     def dialog?
       Trestle.deprecator.warn("`Trestle::Form#dialog?` is deprecated. Please use `modal?` instead.")
       options[:modal]

--- a/spec/trestle/form_spec.rb
+++ b/spec/trestle/form_spec.rb
@@ -21,4 +21,13 @@ describe Trestle::Form do
 
     it { is_expected.to be_modal }
   end
+
+  context "without options[:wrapper]" do
+    it { is_expected.to be_wrapper }
+  end
+
+  context "with options[:wrapper] = false" do
+    subject(:form) { Trestle::Form.new(wrapper: false) }
+    it { is_expected.not_to be_wrapper }
+  end
 end


### PR DESCRIPTION
This PR adds the ability to disable the default form wrapper (container `<div>` including sidebar), and instead leave it to the form partial to lay out the container. This can be useful for laying out a form in sections, or within a grid.

```ruby
Trestle.resource(:articles) do
  form wrapper: false
end
```