### PR TITLE
Ensure check box and radio button labels have the correct for attribute when using a custom id

### DIFF
--- a/lib/trestle/form/fields/check_box.rb
+++ b/lib/trestle/form/fields/check_box.rb
@@ -22,9 +22,21 @@ module Trestle
           tag.div(class: wrapper_class) do
             safe_join([
               builder.raw_check_box(name, options.merge(class: input_class), checked_value, unchecked_value),
-              builder.label(name, options[:label] || admin.human_attribute_name(name), class: label_class, value: (checked_value if options[:multiple]))
+              builder.label(name, label, label_options)
             ])
           end
+        end
+
+        def label
+          options[:label] || admin.human_attribute_name(name)
+        end
+
+        def label_options
+          {
+            class: label_class,
+            value: (checked_value if options[:multiple]),
+            for: options[:id]
+          }.compact
         end
 
         def extract_wrapper_options!

--- a/lib/trestle/form/fields/radio_button.rb
+++ b/lib/trestle/form/fields/radio_button.rb
@@ -23,9 +23,21 @@ module Trestle
           tag.div(class: wrapper_class) do
             safe_join([
               builder.raw_radio_button(name, tag_value, options.merge(class: input_class)),
-              builder.label(name, options[:label] || tag_value.to_s.humanize, value: tag_value, class: label_class)
+              builder.label(name, label, label_options)
             ])
           end
+        end
+
+        def label
+          options[:label] || tag_value.to_s.humanize
+        end
+
+        def label_options
+          {
+            class: label_class,
+            value: tag_value,
+            for: options[:id]
+          }.compact
         end
 
         def extract_wrapper_options!

--- a/spec/trestle/form/fields/check_box_spec.rb
+++ b/spec/trestle/form/fields/check_box_spec.rb
@@ -39,6 +39,18 @@ describe Trestle::Form::Fields::CheckBox, type: :helper do
     end
   end
 
+  context "when options[:id] is specified" do
+    let(:options) { { id: "custom-id" } }
+
+    it "overrides the id attribute on the input element" do
+      expect(subject).to have_tag("input.form-check-input", with: { id: "custom-id" })
+    end
+
+    it "overrides the for attribute on the label element" do
+      expect(subject).to have_tag("label", with: { for: "custom-id" })
+    end
+  end
+
   context "when options[:label] is specified" do
     let(:options) { { label: "Custom Label" } }
 

--- a/spec/trestle/form/fields/radio_button_spec.rb
+++ b/spec/trestle/form/fields/radio_button_spec.rb
@@ -25,6 +25,18 @@ describe Trestle::Form::Fields::RadioButton, type: :helper do
     end
   end
 
+  context "when options[:id] is specified" do
+    let(:options) { { id: "custom-id" } }
+
+    it "overrides the id attribute on the input element" do
+      expect(subject).to have_tag("input.form-check-input", with: { id: "custom-id" })
+    end
+
+    it "overrides the for attribute on the label element" do
+      expect(subject).to have_tag("label", with: { for: "custom-id" })
+    end
+  end
+
   context "when options[:label] is specified" do
     let(:options) { { label: "Custom Label" } }
 


### PR DESCRIPTION
This PR fixes the label's `for` attribute when using a custom id so that the label remains clickable.

```ruby
check_box :check_box, id: "custom-id"
```

**Previous result:**
```html
<div class="form-check">
  <input name="check_box" type="hidden" value="0" autocomplete="off">
  <input label="Check box" class="form-check-input" type="checkbox" value="1" name="check_box" id="custom-id">
  <label class="form-check-label" for="check_box">Check box</label>
</div>
```

**New result:**
```html
<div class="form-check">
  <input name="check_box" type="hidden" value="0" autocomplete="off">
  <input label="Check box" class="form-check-input" type="checkbox" value="1" name="check_box" id="custom-id">
  <label class="form-check-label" for="custom-id">Check box</label>
</div>
```