### PR TITLE
Support Rails Content-Security-Policy nonces

### DIFF
--- a/app/helpers/trestle/content_security_policy_helper.rb
+++ b/app/helpers/trestle/content_security_policy_helper.rb
@@ -1,0 +1,35 @@
+module Trestle
+  module ContentSecurityPolicyHelper
+    def javascript_include_tag(*sources)
+      options = sources.extract_options!.stringify_keys
+
+      if !options.key?("nonce") && content_security_policy_nonce
+        if Rails.gem_version >= Gem::Version.new("6.0.0")
+          options["nonce"] = true
+        else
+          options["nonce"] = content_security_policy_nonce
+        end
+      end
+
+      sources << options
+
+      super(*sources)
+    end
+
+    def stylesheet_link_tag(*sources)
+      options = sources.extract_options!.stringify_keys
+
+      if !options.key?("nonce") && content_security_policy_nonce
+        if Rails.gem_version >= Gem::Version.new("8.0.0")
+          options["nonce"] = true
+        else
+          options["nonce"] = content_security_policy_nonce
+        end
+      end
+
+      sources << options
+
+      super(*sources)
+    end
+  end
+end

--- a/sandbox/app/views/layouts/application.html.erb
+++ b/sandbox/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>Dummy</title>
     <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbo-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload' %>

--- a/sandbox/config/initializers/content_security_policy.rb
+++ b/sandbox/config/initializers/content_security_policy.rb
@@ -1,0 +1,25 @@
+# Be sure to restart your server when you modify this file.
+
+# Define an application-wide content security policy.
+# See the Securing Rails Applications Guide for more information:
+# https://guides.rubyonrails.org/security.html#content-security-policy-header
+
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https, :unsafe_inline
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/spec/trestle/helpers/content_security_policy_helper_spec.rb
+++ b/spec/trestle/helpers/content_security_policy_helper_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe Trestle::ContentSecurityPolicyHelper, type: :helper do
+  shared_context "rails_version" do |version_string|
+    before do
+      allow(Rails).to receive(:gem_version).and_return(Gem::Version.new(version_string))
+    end
+  end
+
+  describe "#javascript_include_tag" do
+    let(:script_name) { "application" }
+
+    context "when content_security_policy is enabled" do
+      context "when content_security_policy_nonce is 'testnonce'" do
+        before { allow(helper).to receive(:content_security_policy_nonce).and_return("testnonce") }
+
+        it "adds the nonce attribute" do
+          expect(helper.javascript_include_tag(script_name)).to have_tag("script[src*='#{script_name}'][nonce='testnonce']")
+        end
+
+        it "does not override an existing nonce option" do
+          expect(helper.javascript_include_tag(script_name, nonce: "custom")).to have_tag("script[src*='#{script_name}'][nonce='custom']")
+        end
+
+        it "preserves other options" do
+          expect(helper.javascript_include_tag(script_name, defer: true)).to have_tag("script[src*='#{script_name}'][nonce='testnonce'][defer='defer']")
+        end
+      end
+    end
+
+    context "when content_security_policy is enabled on rails versions before nonce: true" do
+      context "when content_security_policy_nonce is 'testnonce'" do
+        before { allow(helper).to receive(:content_security_policy_nonce).and_return("testnonce") }
+
+        context "with Rails < 6.0.0" do
+          include_context "rails_version", "5.2.0"
+          it "adds nonce attribute with the direct nonce value" do
+            expect(helper.javascript_include_tag(script_name)).to have_tag("script[src*='#{script_name}'][nonce='testnonce']")
+          end
+        end
+      end
+    end
+
+    context "when content_security_policy_nonce is nil (CSP disabled)" do
+      before { allow(helper).to receive(:content_security_policy_nonce).and_return(nil) }
+
+      it "does not add a nonce attribute" do
+        expect(helper.javascript_include_tag(script_name)).to have_tag("script[src*='#{script_name}']")
+        expect(helper.javascript_include_tag(script_name)).not_to include("nonce=")
+      end
+    end
+  end
+
+  describe "#stylesheet_link_tag" do
+    let(:style_name) { "application" }
+
+    context "when content_security_policy is enabled" do
+      context "when content_security_policy_nonce is 'testnonce'" do
+        before { allow(helper).to receive(:content_security_policy_nonce).and_return("testnonce") }
+
+        it "adds the nonce attribute" do
+          expect(helper.stylesheet_link_tag(style_name)).to have_tag("link[href*='#{style_name}'][rel='stylesheet'][nonce='testnonce']")
+        end
+
+        it "does not override an existing nonce option" do
+          expect(helper.stylesheet_link_tag(style_name, nonce: "custom")).to have_tag("link[href*='#{style_name}'][rel='stylesheet'][nonce='custom']")
+        end
+
+        it "preserves other options like media" do
+          expect(helper.stylesheet_link_tag(style_name, media: "print")).to have_tag("link[href*='#{style_name}'][rel='stylesheet'][media='print'][nonce='testnonce']")
+        end
+      end
+    end
+
+    context "when content_security_policy is enabled on Rails versions before nonce: true" do
+      context "when content_security_policy_nonce is 'testnonce'" do
+        before { allow(helper).to receive(:content_security_policy_nonce).and_return("testnonce") }
+
+        context "with Rails < 8.0.0" do
+          it "adds nonce attribute with the direct nonce value" do
+            expect(helper.stylesheet_link_tag(style_name)).to have_tag("link[href*='#{style_name}'][rel='stylesheet'][nonce='testnonce']")
+          end
+        end
+      end
+    end
+
+    context "when content_security_policy_nonce is nil (CSP disabled)" do
+      before { allow(helper).to receive(:content_security_policy_nonce).and_return(nil) }
+
+      it "does not add a nonce attribute" do
+        expect(helper.stylesheet_link_tag(style_name)).to have_tag("link[href*='#{style_name}'][rel='stylesheet']")
+        expect(helper.stylesheet_link_tag(style_name)).not_to include("nonce=")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #529 

This change adds initial support for [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy) provided by Rails. This primarily focuses on nonces which are necessary to avoid `unsafe-inline`. For scripts this is more important, but due to the fact that stylesheets can also support this in Rails, it includes those as well.

I've also updated the sandbox to enable a content security policy, but I didn't fully enable it for styles because it's quite a task to do "properly" and sandbox is more of an example to showcase Trestle from what I understand.