### PR TITLE
Use :unprocessable_content to support Rack's changes

### DIFF
--- a/app/controllers/concerns/trestle/resource/controller/actions.rb
+++ b/app/controllers/concerns/trestle/resource/controller/actions.rb
@@ -36,9 +36,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("create.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "new", status: :unprocessable_entity }
-              format.turbo_stream { render "create", status: :unprocessable_entity } if modal_request?
-              format.json { render json: instance.errors, status: :unprocessable_entity }
+              format.html { render "new", status: :unprocessable_content }
+              format.turbo_stream { render "create", status: :unprocessable_content } if modal_request?
+              format.json { render json: instance.errors, status: :unprocessable_content }
 
               yield format if block_given?
             end
@@ -98,9 +98,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("update.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "show", status: :unprocessable_entity }
-              format.turbo_stream { render "update", status: :unprocessable_entity }
-              format.json { render json: instance.errors, status: :unprocessable_entity }
+              format.html { render "show", status: :unprocessable_content }
+              format.turbo_stream { render "update", status: :unprocessable_content }
+              format.json { render json: instance.errors, status: :unprocessable_content }
 
               yield format if block_given?
             end


### PR DESCRIPTION
It has been about a year since the release of this work, but https://github.com/rack/rack/pull/2137 introduced a deprecation warning about using `:unprocessable_entity` which should now be `:unprocessable_content`.

```
warning: Status code :unprocessable_entity is deprecated and will be removed in a future version of Rack. Please use :unprocessable_content instead.
```

This change simply changes that symbol.