### PR TITLE
Use :unprocessable_content response status when using Rack 3.1

### DIFF
--- a/app/controllers/concerns/trestle/resource/controller/actions.rb
+++ b/app/controllers/concerns/trestle/resource/controller/actions.rb
@@ -2,6 +2,12 @@ module Trestle
   class Resource
     module Controller
       module Actions
+        if Gem::Version.new(Rack::RELEASE) < Gem::Version.new("3.1")
+          UNPROCESSABLE_CONTENT = :unprocessable_entity
+        else
+          UNPROCESSABLE_CONTENT = :unprocessable_content
+        end
+
         def index
           respond_to do |format|
             format.html
@@ -36,9 +42,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("create.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "new", status: :unprocessable_content }
-              format.turbo_stream { render "create", status: :unprocessable_content } if modal_request?
-              format.json { render json: instance.errors, status: :unprocessable_content }
+              format.html { render "new", status: UNPROCESSABLE_CONTENT }
+              format.turbo_stream { render "create", status: UNPROCESSABLE_CONTENT } if modal_request?
+              format.json { render json: instance.errors, status: UNPROCESSABLE_CONTENT }
 
               yield format if block_given?
             end
@@ -98,9 +104,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("update.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "show", status: :unprocessable_content }
-              format.turbo_stream { render "update", status: :unprocessable_content }
-              format.json { render json: instance.errors, status: :unprocessable_content }
+              format.html { render "show", status: UNPROCESSABLE_CONTENT }
+              format.turbo_stream { render "update", status: UNPROCESSABLE_CONTENT }
+              format.json { render json: instance.errors, status: UNPROCESSABLE_CONTENT }
 
               yield format if block_given?
             end

--- a/app/controllers/concerns/trestle/resource/controller/actions.rb
+++ b/app/controllers/concerns/trestle/resource/controller/actions.rb
@@ -36,9 +36,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("create.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "new", status: :unprocessable_entity }
-              format.turbo_stream { render "create", status: :unprocessable_entity } if modal_request?
-              format.json { render json: instance.errors, status: :unprocessable_entity }
+              format.html { render "new", status: :unprocessable_content }
+              format.turbo_stream { render "create", status: :unprocessable_content } if modal_request?
+              format.json { render json: instance.errors, status: :unprocessable_content }
 
               yield format if block_given?
             end
@@ -98,9 +98,9 @@ module Trestle
             respond_to do |format|
               flash.now[:error] = flash_message("update.failure", title: "Warning!", message: "Please correct the errors below.")
 
-              format.html { render "show", status: :unprocessable_entity }
-              format.turbo_stream { render "update", status: :unprocessable_entity }
-              format.json { render json: instance.errors, status: :unprocessable_entity }
+              format.html { render "show", status: :unprocessable_content }
+              format.turbo_stream { render "update", status: :unprocessable_content }
+              format.json { render json: instance.errors, status: :unprocessable_content }
 
               yield format if block_given?
             end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ApplicationRecord
   scope :published, -> { where(published: true) }
+
+  validates :title, presence: true
 end

--- a/spec/feature/resource_spec.rb
+++ b/spec/feature/resource_spec.rb
@@ -22,6 +22,16 @@ feature 'Resources', type: :system do
     expect(page).to have_current_path(/\/admin\/posts\/\d+/)
   end
 
+  scenario 'new record with errors' do
+    visit '/admin/posts'
+
+    click_link "New Post"
+    click_button "Save Post"
+
+    expect(page).to have_content("Please correct the errors below.")
+    expect(page).to have_current_path(/\/admin\/posts\/new/)
+  end
+
   scenario 'update record' do
     create_test_post
 
@@ -32,6 +42,18 @@ feature 'Resources', type: :system do
     click_button "Save Post"
 
     expect(page).to have_content("The post was successfully updated.")
+  end
+
+  scenario 'update record with errors' do
+    create_test_post
+
+    visit '/admin/posts'
+    click_link "First Post"
+
+    fill_in "Title", with: ""
+    click_button "Save Post"
+
+    expect(page).to have_content("Please correct the errors below.")
   end
 
   scenario 'delete record' do


### PR DESCRIPTION
Alternative approach to #545. Updates the resource controller actions to respond with `:unprocessable_content` status instead of the now deprecated `:unprocessable_entity` status when using >= Rack 3.1.

This approach retains compatibility with Rack 2.x (thereby continuing compatibility with Rails 6.x & Rails 7.0).